### PR TITLE
Modernized travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: cpp
-
 os:
   - linux
 
-git:
-  submodules: false
+sudo: false
+
+cache:
+    directories:
+        - $HOME/cmake
 
 addons:
   apt:
@@ -15,6 +17,10 @@ addons:
       - g++-4.8
       - libx11-dev
       - libgl1-mesa-dev
+      - xorg-dev
+      - libglu1-mesa-dev
+      - libglew-dev
+      - libopenal-dev
 
 compiler:
   - gcc
@@ -22,22 +28,21 @@ compiler:
 # Bullet compiling fails with CLang, so we not use it yet..
 
 before_install:
-  - git submodule update --init
-  - echo $LANG
-  - echo $LC_ALL
   - sudo apt-get update -qq
-
-install:
-  # Install CMake 3.1
-  - (cd /tmp && wget http://www.cmake.org/files/v3.1/cmake-3.1.3.tar.gz && tar zxf cmake-3.1.3.tar.gz)
-  - (cd /tmp/cmake-3.1.3 && cmake . && make && sudo make install) > /dev/null 2>&1
-  - cmake --version
+  - git submodule update --init
   # Enforces GCC 4.8
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
   # Enforces CLang 3.7
   - if [ "$CXX" == "clang++" ]; then export CXX="clang++-3.7"; fi
-  # Install OpenAL and GLEW
-  - sudo apt-get -q -y install libglew-dev libopenal-dev
+  - echo $LANG
+  - echo $LC_ALL
+    # Grabs Cmake 3.2
+  - ./travis/install_cmake.sh
+  - ls $HOME/cmake/
+  - export PATH=$HOME/cmake/:$HOME/cmake/bin/:$PATH
+  - cmake --version
+
+install:
 
 before_script:
   - pwd
@@ -57,12 +62,9 @@ script:
   - ./bin/UNIT_TEST
 
 notifications:
-  #email:
-    #- my.mail@bar.com
-  # I can also set up Glitch to output build results as well if we don't want the travis bot join/part spam
-  irc:
-    channels:
-      - "chat.freenode.net#project-trillek"
-      - "chat.freenode.net#trillek"
-    on_success: change
-    on_failure: always
+#  irc:
+#    channels:
+#      - "chat.freenode.net#project-trillek"
+#      - "chat.freenode.net#trillek"
+#    on_success: change
+#    on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,10 +52,10 @@ script:
   - echo "Building dependencies (bullet) and installing it"
   - cmake ..
   - make
-  - sudo make install
+  - make install DESTDIR="$HOME"
   - echo "Building TEC"
   - rm -f cmakecache.txt
-  - cmake -DBUILD_TESTS_TEC=True ..
+  - cmake -DCMAKE_INCLUDE_PATH=$HOME/usr/local/include -DCMAKE_LIBRARY_PATH=$HOME/usr/local/lib  -DBUILD_TESTS_TEC=True ..
   - make
   - ls
   - ./bin/UNIT_TEST

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,52 @@
 language: cpp
-os:
-  - linux
 
 sudo: false
 
 cache:
-    directories:
+    - directories:
         - $HOME/cmake
+        - $HOME/lib
 
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - gcc-4.8
-      - g++-4.8
-      - libx11-dev
-      - libgl1-mesa-dev
-      - xorg-dev
-      - libglu1-mesa-dev
-      - libglew-dev
-      - libopenal-dev
+matrix:
+    include:
+        - os: linux
+          compiler: gcc
+          addons:
+              apt:
+                sources: ['ubuntu-toolchain-r-test']
+                packages:
+                  - gcc-4.9
+                  - g++-4.9
+                  - libx11-dev
+                  - libgl1-mesa-dev
+                  - xorg-dev
+                  - libglu1-mesa-dev
+                  - libglew-dev
+                  - libopenal-dev
+          env: COMPILER=g++-4.9
 
-compiler:
-  - gcc
-  #- clang
-# Bullet compiling fails with CLang, so we not use it yet..
+        - os: linux
+          compiler: clang
+          addons:
+              apt:
+                sources:
+                    - ubuntu-toolchain-r-test
+                    - llvm-toolchain-precise-3.7
+                packages:
+                  - clang-3.7
+                  - libx11-dev
+                  - libgl1-mesa-dev
+                  - xorg-dev
+                  - libglu1-mesa-dev
+                  - libglew-dev
+                  - libopenal-dev
+          env: COMPILER=clang++-3.7
+
 
 before_install:
   - git submodule update --init
-  # Enforces GCC 4.8
-  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
-  # Enforces CLang 3.7
-  - if [ "$CXX" == "clang++" ]; then export CXX="clang++-3.7"; fi
+  - export CXX="$COMPILER"
+  - ${CXX} --version
   - echo $LANG
   - echo $LC_ALL
     # Grabs Cmake 3.2
@@ -49,21 +63,21 @@ before_script:
   - cd build
 
 script:
-  - echo "Building dependencies (bullet) and installing it"
-  - cmake ..
-  - make
-  - make install DESTDIR="$HOME"
+  - ../travis/build_deps.sh
+  #- cmake ..
+  #- make
+  #- make install DESTDIR="$HOME/lib/$COMPILER"
   - echo "Building TEC"
   - rm -f cmakecache.txt
-  - cmake -DCMAKE_INCLUDE_PATH=$HOME/usr/local/include -DCMAKE_LIBRARY_PATH=$HOME/usr/local/lib  -DBUILD_TESTS_TEC=True ..
+  - cmake -DCMAKE_INCLUDE_PATH=$HOME/lib/${COMPILER}/usr/local/include -DCMAKE_LIBRARY_PATH=$HOME/lib/${COMPILER}/usr/local/lib  -DBUILD_TESTS_TEC=True ..
   - make
   - ls
   - ./bin/UNIT_TEST
 
 notifications:
-#  irc:
-#    channels:
+  irc:
+    channels:
 #      - "chat.freenode.net#project-trillek"
-#      - "chat.freenode.net#trillek"
-#    on_success: change
-#    on_failure: always
+      - "chat.freenode.net#trillek"
+    on_success: change
+    on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ compiler:
 # Bullet compiling fails with CLang, so we not use it yet..
 
 before_install:
-  - sudo apt-get update -qq
   - git submodule update --init
   # Enforces GCC 4.8
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Trillek Engine C
-| GNU/Linux                                        | Windows (VStudio 2015)  |
+| GNU/Linux (Gcc and CLang)                        | Windows (VStudio 2015)  |
 |--------------------------------------------------|-------------------------|
 |[![Build Status](https://travis-ci.org/trillek-team/tec.svg)](https://travis-ci.org/trillek-team/tec) | [![Build status](https://ci.appveyor.com/api/projects/status/n89l3qj4oo2v20th?svg=true)](https://ci.appveyor.com/project/Zardoz89/tec-ojmoq) |
 
@@ -19,7 +19,7 @@ Building takes a few steps to get everything set up for the first build.
 2. `mkdir build/` in to root directory
 3. `cd build/`
 4. Follow platform specific instructions 
-  1. Linux 
+  1. Linux (G++ 3.9 or CLang 3.7)
      - If you have Bullet, GLEW and OpenAL dev libs installed : 
        1. `cmake ..` in the build directory
        2. `make TEC` in the build directory
@@ -30,7 +30,7 @@ Building takes a few steps to get everything set up for the first build.
        4. `rm CMakeCache.txt` in the build directory
        5. `cmake ..` in the build directory
        6. `make TEC` in the build directory
-  2. Windows
+  2. Windows (VStudio 2015)
      1. Run cmake-gui setting the source line to the root directory and the build line to the build directory.
      2. Configure and Generate using non-x64 as the target, with native compiles selected.
      3. Build all dependencies in Release configuration (if it is just tec in the project list go to step 5).

--- a/travis/build_deps.sh
+++ b/travis/build_deps.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ ! -d "$HOME/lib/$COMPILER" ]; then
+    echo "Building dependencies (bullet)"
+    mkdir -p $HOME/lib
+    cmake ..
+    make
+    make install DESTDIR="$HOME/lib/$COMPILER"
+else
+    echo "Dependencies on cache";
+fi
+

--- a/travis/install_cmake.sh
+++ b/travis/install_cmake.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+if [ ! -d "$HOME/cmake/bin" ]; then
+    #Download CMake 3.2
+    wget http://www.cmake.org/files/v3.2/cmake-3.2.3-Linux-x86_64.tar.gz
+    mkdir -p $HOME/cmake
+    tar zxf cmake-3.2.3-Linux-x86_64.tar.gz -C $HOME/cmake --strip-components=1
+else
+    echo "CMake - Using cached directory";
+fi
+


### PR DESCRIPTION
Should use the new travis ci infrastructure.
Also, saves on cache cmake 3.2, avoiding to recompile all the time.