### PR TITLE
Caught some chances to crash if assets didn't load

### DIFF
--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -209,9 +209,15 @@ FilePath FilePath::GetUserCachePath() {
 
 bool FilePath::DirExists() const {
 #if defined(WIN32)
-	struct __stat64 s;
+	struct _stat s;
 	auto wtmp = this->GetNativePath();
-	int err = _wstat64((wchar_t*)wtmp.c_str() , &s);
+
+	// Trailing slashes break _wstat
+	wchar_t *p = &wtmp[wcslen(&wtmp[0]) - 1];
+	if (*p == L'/' || *p == L'\\') {
+		*p = 0;
+	}
+	int err = _wstat((wchar_t*)wtmp.c_str() , &s);
 #else
 	struct stat s;
 	int err = stat(path.c_str(), &s);

--- a/src/graphics/animation.cpp
+++ b/src/graphics/animation.cpp
@@ -9,7 +9,9 @@
 namespace tec {
 	Animation::Animation(std::shared_ptr<MD5Anim> animation) : animation_time(0.0f), frame_count(0) {
 		SetAnimationFile(animation);
-		this->animation_name = animation_file->GetName();
+		if (animation) {
+			this->animation_name = animation_file->GetName();
+		}
 	}
 	void Animation::UpdateAnimation(const double delta) {
 		if (this->frame_count < 1) {

--- a/src/graphics/shader.cpp
+++ b/src/graphics/shader.cpp
@@ -32,7 +32,7 @@ namespace tec {
 			return;
 		}
 		std::ifstream fp(fname.GetNativePath(), std::ios_base::in);
-		if (! fp.is_open()) {
+		if (!fp.is_open()) {
 			_log->error() << "[Shader] Error loading shader: " << fname.FileName() << " Can't open file.";
 			return;
 		}
@@ -98,9 +98,8 @@ namespace tec {
 
 			std::vector<GLchar> info_log(max_length);
 			glGetProgramInfoLog(this->program, max_length, &max_length, &info_log[0]);
-			std::string str;
-			str.copy(info_log.data(), info_log.size());
-			str[info_log.size() - 1] = '\0';
+			std::string str(info_log.data());
+			str += '\0';
 			spdlog::get("console_log")->error("[Shader] Error linking : {}", str);
 
 			DeleteProgram();

--- a/src/render-system.cpp
+++ b/src/render-system.cpp
@@ -29,9 +29,22 @@ namespace tec {
 
 		// Black is the safest clear color since this is a space game.
 		glClearColor(0.0, 0.0, 0.0, 0.0);
-
-		this->sphere_vbo.Load(OBJ::Create(FilePath::GetAssetPath("/sphere/sphere.obj")));
-		this->quad_vbo.Load(OBJ::Create(FilePath::GetAssetPath("/quad/quad.obj")));
+		std::shared_ptr<OBJ> spehre = OBJ::Create(FilePath::GetAssetPath("/sphere/sphere.obj"));
+		if (!spehre) {
+			_log->debug("[RenderSystem] Error loading sphere.obj.");
+			this->sphere_vbo.Load(std::vector<VertexData>(), std::vector<GLuint>());
+		}
+		else {
+			this->sphere_vbo.Load(spehre);
+		}
+		std::shared_ptr<OBJ> quad = OBJ::Create(FilePath::GetAssetPath("/quad/quad.obj"));
+		if (!quad) {
+			_log->debug("[RenderSystem] Error loading quad.obj.");
+			this->quad_vbo.Load(std::vector<VertexData>(), std::vector<GLuint>());
+		}
+		else {
+			this->quad_vbo.Load(quad);
+		}
 
 		this->light_gbuffer.AddColorAttachments(4, this->window_width, this->window_height);
 		this->light_gbuffer.SetDepthAttachment(GBuffer::GBUFFER_DEPTH_TYPE_STENCIL,


### PR DESCRIPTION
Fixed FilePath::DirExists to remove trailing slash on WIN32 due to OS inconsistencies.