### PR TITLE
Enforce OpenGL 3.3 and check GLSL version

### DIFF
--- a/include/os.hpp
+++ b/include/os.hpp
@@ -24,10 +24,12 @@ namespace tec {
 		*
 		* \param[in] const unsigned int width, height The window's client width and height
 		* \param[in] const std::string title The title to show in the title bar and task manager.
+		* \param[in] const glMajor OpenGL major version number. Must be >= 3
+		* \param[in] const glMinor OpenGL minor version. If major = 3, must be 3 (OpenGL 3.3)
 		* \return bool If creation was successful or not.
 		*/
 		bool InitializeWindow(const int width, const int height, const std::string title,
-			const unsigned int glMajor = 3, const unsigned int glMinor = 2);
+			const unsigned int glMajor = 3, const unsigned int glMinor = 3);
 
 		/** \brief Make the context of the window current for the calling thread
 		*

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -100,7 +100,7 @@ int main(int argc, char* argv[]) {
 
 	log->info("Initializing OpenGL...");
 	tec::OS os;
-	os.InitializeWindow(1024, 768, "TEC 0.1", 3, 2);
+	os.InitializeWindow(1024, 768, "TEC 0.1", 3,3);
 	console.AddConsoleCommand( "exit", 
 		"exit : Exit from TEC",
 		[&os ] (const char* args) {


### PR DESCRIPTION
We are using GLSL 3.30 shaders, so the minimun OpengL must be 3.3 .
Also, actually all the GPU s that support OpenGL 3, can support OpenGL
3.3 (including OSX)

Should close #58 