### PR TITLE
Refactor of types.hpp

### DIFF
--- a/include/graphics/lights.hpp
+++ b/include/graphics/lights.hpp
@@ -30,7 +30,7 @@ namespace tec {
 		}
 
 		void Out(proto::Component* target) {
-			proto::Light* comp = target->mutable_dirlight();
+			proto::Light* comp = target->mutable_directionallight();
 			comp->set_color_x(this->color.x);
 			comp->set_color_y(this->color.y);
 			comp->set_color_z(this->color.z);
@@ -43,7 +43,7 @@ namespace tec {
 		}
 
 		void In(const proto::Component& source) {
-			const proto::Light& comp = source.dirlight();
+			const proto::Light& comp = source.directionallight();
 			if (comp.has_color_x()) {
 				this->color.x = comp.color_x();
 			}
@@ -102,7 +102,7 @@ namespace tec {
 		}
 
 		void Out(proto::Component* target) {
-			proto::Light* comp = target->mutable_light();
+			proto::Light* comp = target->mutable_pointlight();
 			comp->set_color_x(this->color.x);
 			comp->set_color_y(this->color.y);
 			comp->set_color_z(this->color.z);
@@ -115,7 +115,7 @@ namespace tec {
 		}
 
 		void In(const proto::Component& source) {
-			const proto::Light& comp = source.light();
+			const proto::Light& comp = source.pointlight();
 			if (comp.has_color_x()) {
 				this->color.x = comp.color_x();
 			}

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -1,72 +1,107 @@
 #pragma once
 
+/**
+ * @file types.hpp
+ * Here we define some typedefs of some usual types used across the whole project, plus some 
+ * templated helper functions for reflection
+ */
+
 #include <cstdint>
+#include <unordered_map>
+
 #include "../proto/components.pb.h"
 
 namespace tec {
 	typedef std::int64_t frame_id_t;
 
-	typedef std::int64_t GUID;
+	typedef std::int64_t GUID; /// Global Unique ID
 
-	typedef std::int64_t eid;
+	typedef std::int64_t eid; /// Entoty ID
 
+	typedef std::uint32_t tid; /// Type ID
+
+	/// Returns the name of an component on compile time
 	template<class TYPE> const char* GetTypeName(void) { return "UNKNOWN"; }
-	template<class TYPE> proto::Component::ComponentCase GetComponentCase(void) { return proto::Component::ComponentCase::COMPONENT_NOT_SET; }
-	template<class TYPE> unsigned int GetTypeID(void) { return ~0; }
+	/// Returns the TypeID of a component on compile time
+	template<class TYPE> const tid GetTypeID(void) { return proto::Component::COMPONENT_NOT_SET; }
+	/// Returns the name of a resource type on Compile time 
 	template<class TYPE> const char* GetTypeEXT(void) { return "UNKNOWN"; }
 
-#define MAKE_IDTYPE(a,b) \
+	/*
+	 * Use this macro to associate a component to an type id and generat a string withthe name
+	 * Only works if the struct and component name on .proto file are the same (see the list on message Component )
+	 */
+#define MAKE_IDTYPE(a) \
 	template<> inline const char* GetTypeName<a>() { return #a; } \
-	template<> inline unsigned int GetTypeID<a>() { return b; }
-#define MAKE_COMPONENTCASETYPE(a,b) \
-	template<> inline proto::Component::ComponentCase GetComponentCase<a>() { return b; }
-#define MAKE_EXTTYPE(a,b) \
+	template<> inline const tid GetTypeID<a>() { return proto::Component::k##a;}
+
+#define MAKE_IDTYPE_NAMESPACE(ns, a, b) \
+	template<> inline const char* GetTypeName<ns::a>() { return #a; } \
+	template<> inline const tid GetTypeID<ns::a>() { return proto::Component::k##a;}
+
+#define MAKE_EXTTYPE(a, b) \
 	template<> inline const char* GetTypeName<a>() { return #a; } \
 	template<> inline const char* GetTypeEXT<a>() { return b; }
-#define MAKE_IDTYPE_NAMESPACE(ns,a,b) \
-	template<> inline const char* GetTypeName<ns::a>() { return #a; } \
-	template<> inline unsigned int GetTypeID<ns::a>() { return b; }
+
+	// Registering components
 
 	struct Renderable;
-	MAKE_IDTYPE(Renderable, 0);
-	MAKE_COMPONENTCASETYPE(Renderable, proto::Component::kRenderable);
+	MAKE_IDTYPE(Renderable); //kRenderable of proto::Component enum
+
 	struct Position;
-	MAKE_IDTYPE(Position, 1);
-	MAKE_COMPONENTCASETYPE(Position, proto::Component::kPosition);
+	MAKE_IDTYPE(Position);
+
 	struct Orientation;
-	MAKE_IDTYPE(Orientation, 2);
-	MAKE_COMPONENTCASETYPE(Orientation, proto::Component::kOrientation);
+	MAKE_IDTYPE(Orientation);
+
 	struct View;
-	MAKE_IDTYPE(View, 3);
-	MAKE_COMPONENTCASETYPE(View, proto::Component::kView);
+	MAKE_IDTYPE(View);
+
 	class Animation;
-	MAKE_IDTYPE(Animation, 4);
-	MAKE_COMPONENTCASETYPE(Animation, proto::Component::kAnimation);
+	MAKE_IDTYPE(Animation);
+
 	struct Scale;
-	MAKE_IDTYPE(Scale, 5);
-	MAKE_COMPONENTCASETYPE(Scale, proto::Component::kScale);
+	MAKE_IDTYPE(Scale);
+
 	struct CollisionBody;
-	MAKE_IDTYPE(CollisionBody, 6);
-	MAKE_COMPONENTCASETYPE(CollisionBody, proto::Component::kCollisionBody);
+	MAKE_IDTYPE(CollisionBody);
+
 	struct Velocity;
-	MAKE_IDTYPE(Velocity, 7);
-	MAKE_COMPONENTCASETYPE(Velocity, proto::Component::kVelocity);
+	MAKE_IDTYPE(Velocity);
+
 	struct AudioSource;
-	MAKE_IDTYPE(AudioSource, 8);
-	MAKE_COMPONENTCASETYPE(AudioSource, proto::Component::kAudioSource);
+	MAKE_IDTYPE(AudioSource);
+
 	struct PointLight;
-	MAKE_IDTYPE(PointLight, 9);
-	MAKE_COMPONENTCASETYPE(PointLight, proto::Component::kLight);
-	struct DirectionalLight;
-	MAKE_IDTYPE(DirectionalLight, 10);
-	MAKE_COMPONENTCASETYPE(DirectionalLight, proto::Component::kDirlight);
+	MAKE_IDTYPE(PointLight);
+
+	struct DirectionalLight; 
+	MAKE_IDTYPE(DirectionalLight);
+
+	// SpotLight ??
+
 	class VoxelVolume;
-	MAKE_IDTYPE(VoxelVolume, 11);
+	MAKE_IDTYPE(VoxelVolume);
+
+
+	// Register Resource filetypes
 
 	class MD5Mesh;
 	MAKE_EXTTYPE(MD5Mesh, "md5mesh");
+
 	class OBJ;
 	MAKE_EXTTYPE(OBJ, "obj");
+
 	class VorbisStream;
 	MAKE_EXTTYPE(VorbisStream, "ogg");
+
+
+	/// Maps on runtime the Type ID with the name
+	extern const std::unordered_map<tid, const char*> TypeName;
+
+#undef MAKE_EXTTYPE
+#undef MAKE_IDTYPE_NAMESPACE
+#undef MAKE_IDTYPE
+
 }
+

--- a/proto/components.pb.cc
+++ b/proto/components.pb.cc
@@ -77,6 +77,9 @@ const ::google::protobuf::internal::GeneratedMessageReflection*
 const ::google::protobuf::Descriptor* Light_Direction_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   Light_Direction_reflection_ = NULL;
+const ::google::protobuf::Descriptor* VoxelVolumen_descriptor_ = NULL;
+const ::google::protobuf::internal::GeneratedMessageReflection*
+  VoxelVolumen_reflection_ = NULL;
 const ::google::protobuf::Descriptor* Component_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
   Component_reflection_ = NULL;
@@ -90,9 +93,10 @@ struct ComponentOneofInstance {
   const ::tec::proto::CollisionBody* collision_body_;
   const ::tec::proto::Velocity* velocity_;
   const ::tec::proto::AudioSource* audio_source_;
-  const ::tec::proto::Light* light_;
-  const ::tec::proto::Light* dirlight_;
+  const ::tec::proto::Light* pointlight_;
+  const ::tec::proto::Light* directionallight_;
   const ::tec::proto::Light* spotlight_;
+  const ::tec::proto::VoxelVolumen* voxelvolume_;
 }* Component_default_oneof_instance_ = NULL;
 const ::google::protobuf::Descriptor* Entity_descriptor_ = NULL;
 const ::google::protobuf::internal::GeneratedMessageReflection*
@@ -410,8 +414,23 @@ void protobuf_AssignDesc_components_2eproto() {
       sizeof(Light_Direction),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Light_Direction, _internal_metadata_),
       -1);
-  Component_descriptor_ = file->message_type(10);
-  static const int Component_offsets_[13] = {
+  VoxelVolumen_descriptor_ = file->message_type(10);
+  static const int VoxelVolumen_offsets_[1] = {
+    GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(VoxelVolumen, dummy_),
+  };
+  VoxelVolumen_reflection_ =
+    ::google::protobuf::internal::GeneratedMessageReflection::NewGeneratedMessageReflection(
+      VoxelVolumen_descriptor_,
+      VoxelVolumen::default_instance_,
+      VoxelVolumen_offsets_,
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(VoxelVolumen, _has_bits_[0]),
+      -1,
+      -1,
+      sizeof(VoxelVolumen),
+      GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(VoxelVolumen, _internal_metadata_),
+      -1);
+  Component_descriptor_ = file->message_type(11);
+  static const int Component_offsets_[14] = {
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(Component_default_oneof_instance_, renderable_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(Component_default_oneof_instance_, position_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(Component_default_oneof_instance_, orientation_),
@@ -421,9 +440,10 @@ void protobuf_AssignDesc_components_2eproto() {
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(Component_default_oneof_instance_, collision_body_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(Component_default_oneof_instance_, velocity_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(Component_default_oneof_instance_, audio_source_),
-    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(Component_default_oneof_instance_, light_),
-    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(Component_default_oneof_instance_, dirlight_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(Component_default_oneof_instance_, pointlight_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(Component_default_oneof_instance_, directionallight_),
     PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(Component_default_oneof_instance_, spotlight_),
+    PROTO2_GENERATED_DEFAULT_ONEOF_FIELD_OFFSET(Component_default_oneof_instance_, voxelvolume_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Component, component_),
   };
   Component_reflection_ =
@@ -439,7 +459,7 @@ void protobuf_AssignDesc_components_2eproto() {
       sizeof(Component),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Component, _internal_metadata_),
       -1);
-  Entity_descriptor_ = file->message_type(11);
+  Entity_descriptor_ = file->message_type(12);
   static const int Entity_offsets_[2] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Entity, id_),
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Entity, components_),
@@ -455,7 +475,7 @@ void protobuf_AssignDesc_components_2eproto() {
       sizeof(Entity),
       GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(Entity, _internal_metadata_),
       -1);
-  EntityFileList_descriptor_ = file->message_type(12);
+  EntityFileList_descriptor_ = file->message_type(13);
   static const int EntityFileList_offsets_[1] = {
     GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(EntityFileList, entity_file_list_),
   };
@@ -517,6 +537,8 @@ void protobuf_RegisterTypes(const ::std::string&) {
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       Light_Direction_descriptor_, &Light_Direction::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
+      VoxelVolumen_descriptor_, &VoxelVolumen::default_instance());
+  ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       Component_descriptor_, &Component::default_instance());
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedMessage(
       Entity_descriptor_, &Entity::default_instance());
@@ -562,6 +584,8 @@ void protobuf_ShutdownFile_components_2eproto() {
   delete Light_Attenuation_reflection_;
   delete Light_Direction::default_instance_;
   delete Light_Direction_reflection_;
+  delete VoxelVolumen::default_instance_;
+  delete VoxelVolumen_reflection_;
   delete Component::default_instance_;
   delete Component_default_oneof_instance_;
   delete Component_reflection_;
@@ -614,22 +638,25 @@ void protobuf_AddDesc_components_2eproto() {
     "ection\032D\n\013Attenuation\022\020\n\010constant\030\001 \001(\002\022"
     "\016\n\006linear\030\002 \001(\002\022\023\n\013exponential\030\003 \001(\002\032,\n\t"
     "Direction\022\t\n\001x\030\001 \001(\002\022\t\n\001y\030\002 \001(\002\022\t\n\001z\030\003 \001"
-    "(\002\"\211\004\n\tComponent\022+\n\nrenderable\030\001 \001(\0132\025.t"
-    "ec.proto.RenderableH\000\022\'\n\010position\030\002 \001(\0132"
-    "\023.tec.proto.PositionH\000\022-\n\013orientation\030\003 "
-    "\001(\0132\026.tec.proto.OrientationH\000\022\037\n\004view\030\004 "
-    "\001(\0132\017.tec.proto.ViewH\000\022)\n\tanimation\030\005 \001("
-    "\0132\024.tec.proto.AnimationH\000\022!\n\005Scale\030\006 \001(\013"
-    "2\020.tec.proto.ScaleH\000\0222\n\016collision_body\030\007"
-    " \001(\0132\030.tec.proto.CollisionBodyH\000\022\'\n\010velo"
-    "city\030\010 \001(\0132\023.tec.proto.VelocityH\000\022.\n\014aud"
-    "io_source\030\t \001(\0132\026.tec.proto.AudioSourceH"
-    "\000\022!\n\005light\030\n \001(\0132\020.tec.proto.LightH\000\022$\n\010"
-    "dirlight\030\013 \001(\0132\020.tec.proto.LightH\000\022%\n\tsp"
-    "otlight\030\014 \001(\0132\020.tec.proto.LightH\000B\013\n\tcom"
-    "ponent\">\n\006Entity\022\n\n\002id\030\001 \002(\004\022(\n\ncomponen"
-    "ts\030\002 \003(\0132\024.tec.proto.Component\"*\n\016Entity"
-    "FileList\022\030\n\020entity_file_list\030\001 \003(\t", 2074);
+    "(\002\"\035\n\014VoxelVolumen\022\r\n\005dummy\030\001 \001(\002\"\306\004\n\tCo"
+    "mponent\022+\n\nrenderable\030\001 \001(\0132\025.tec.proto."
+    "RenderableH\000\022\'\n\010position\030\002 \001(\0132\023.tec.pro"
+    "to.PositionH\000\022-\n\013orientation\030\003 \001(\0132\026.tec"
+    ".proto.OrientationH\000\022\037\n\004view\030\004 \001(\0132\017.tec"
+    ".proto.ViewH\000\022)\n\tanimation\030\005 \001(\0132\024.tec.p"
+    "roto.AnimationH\000\022!\n\005Scale\030\006 \001(\0132\020.tec.pr"
+    "oto.ScaleH\000\0222\n\016collision_body\030\007 \001(\0132\030.te"
+    "c.proto.CollisionBodyH\000\022\'\n\010velocity\030\010 \001("
+    "\0132\023.tec.proto.VelocityH\000\022.\n\014audio_source"
+    "\030\t \001(\0132\026.tec.proto.AudioSourceH\000\022&\n\npoin"
+    "tLight\030\n \001(\0132\020.tec.proto.LightH\000\022,\n\020dire"
+    "ctionalLight\030\013 \001(\0132\020.tec.proto.LightH\000\022%"
+    "\n\tspotLight\030\014 \001(\0132\020.tec.proto.LightH\000\022.\n"
+    "\013voxelVolume\030\r \001(\0132\027.tec.proto.VoxelVolu"
+    "menH\000B\013\n\tcomponent\">\n\006Entity\022\n\n\002id\030\001 \002(\004"
+    "\022(\n\ncomponents\030\002 \003(\0132\024.tec.proto.Compone"
+    "nt\"*\n\016EntityFileList\022\030\n\020entity_file_list"
+    "\030\001 \003(\t", 2166);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "components.proto", &protobuf_RegisterTypes);
   Renderable::default_instance_ = new Renderable();
@@ -650,6 +677,7 @@ void protobuf_AddDesc_components_2eproto() {
   Light::default_instance_ = new Light();
   Light_Attenuation::default_instance_ = new Light_Attenuation();
   Light_Direction::default_instance_ = new Light_Direction();
+  VoxelVolumen::default_instance_ = new VoxelVolumen();
   Component::default_instance_ = new Component();
   Component_default_oneof_instance_ = new ComponentOneofInstance();
   Entity::default_instance_ = new Entity();
@@ -671,6 +699,7 @@ void protobuf_AddDesc_components_2eproto() {
   Light::default_instance_->InitAsDefaultInstance();
   Light_Attenuation::default_instance_->InitAsDefaultInstance();
   Light_Direction::default_instance_->InitAsDefaultInstance();
+  VoxelVolumen::default_instance_->InitAsDefaultInstance();
   Component::default_instance_->InitAsDefaultInstance();
   Entity::default_instance_->InitAsDefaultInstance();
   EntityFileList::default_instance_->InitAsDefaultInstance();
@@ -8295,6 +8324,263 @@ void Light::clear_direction() {
 // ===================================================================
 
 #ifndef _MSC_VER
+const int VoxelVolumen::kDummyFieldNumber;
+#endif  // !_MSC_VER
+
+VoxelVolumen::VoxelVolumen()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:tec.proto.VoxelVolumen)
+}
+
+void VoxelVolumen::InitAsDefaultInstance() {
+}
+
+VoxelVolumen::VoxelVolumen(const VoxelVolumen& from)
+  : ::google::protobuf::Message(),
+    _internal_metadata_(NULL) {
+  SharedCtor();
+  MergeFrom(from);
+  // @@protoc_insertion_point(copy_constructor:tec.proto.VoxelVolumen)
+}
+
+void VoxelVolumen::SharedCtor() {
+  _cached_size_ = 0;
+  dummy_ = 0;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+}
+
+VoxelVolumen::~VoxelVolumen() {
+  // @@protoc_insertion_point(destructor:tec.proto.VoxelVolumen)
+  SharedDtor();
+}
+
+void VoxelVolumen::SharedDtor() {
+  if (this != default_instance_) {
+  }
+}
+
+void VoxelVolumen::SetCachedSize(int size) const {
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+}
+const ::google::protobuf::Descriptor* VoxelVolumen::descriptor() {
+  protobuf_AssignDescriptorsOnce();
+  return VoxelVolumen_descriptor_;
+}
+
+const VoxelVolumen& VoxelVolumen::default_instance() {
+  if (default_instance_ == NULL) protobuf_AddDesc_components_2eproto();
+  return *default_instance_;
+}
+
+VoxelVolumen* VoxelVolumen::default_instance_ = NULL;
+
+VoxelVolumen* VoxelVolumen::New(::google::protobuf::Arena* arena) const {
+  VoxelVolumen* n = new VoxelVolumen;
+  if (arena != NULL) {
+    arena->Own(n);
+  }
+  return n;
+}
+
+void VoxelVolumen::Clear() {
+  dummy_ = 0;
+  ::memset(_has_bits_, 0, sizeof(_has_bits_));
+  if (_internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->Clear();
+  }
+}
+
+bool VoxelVolumen::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:tec.proto.VoxelVolumen)
+  for (;;) {
+    ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoff(127);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // optional float dummy = 1;
+      case 1: {
+        if (tag == 13) {
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   float, ::google::protobuf::internal::WireFormatLite::TYPE_FLOAT>(
+                 input, &dummy_)));
+          set_has_dummy();
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectAtEnd()) goto success;
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0 ||
+            ::google::protobuf::internal::WireFormatLite::GetTagWireType(tag) ==
+            ::google::protobuf::internal::WireFormatLite::WIRETYPE_END_GROUP) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:tec.proto.VoxelVolumen)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:tec.proto.VoxelVolumen)
+  return false;
+#undef DO_
+}
+
+void VoxelVolumen::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:tec.proto.VoxelVolumen)
+  // optional float dummy = 1;
+  if (has_dummy()) {
+    ::google::protobuf::internal::WireFormatLite::WriteFloat(1, this->dummy(), output);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        unknown_fields(), output);
+  }
+  // @@protoc_insertion_point(serialize_end:tec.proto.VoxelVolumen)
+}
+
+::google::protobuf::uint8* VoxelVolumen::SerializeWithCachedSizesToArray(
+    ::google::protobuf::uint8* target) const {
+  // @@protoc_insertion_point(serialize_to_array_start:tec.proto.VoxelVolumen)
+  // optional float dummy = 1;
+  if (has_dummy()) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteFloatToArray(1, this->dummy(), target);
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        unknown_fields(), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:tec.proto.VoxelVolumen)
+  return target;
+}
+
+int VoxelVolumen::ByteSize() const {
+  int total_size = 0;
+
+  // optional float dummy = 1;
+  if (has_dummy()) {
+    total_size += 1 + 4;
+  }
+
+  if (_internal_metadata_.have_unknown_fields()) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        unknown_fields());
+  }
+  GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+  _cached_size_ = total_size;
+  GOOGLE_SAFE_CONCURRENT_WRITES_END();
+  return total_size;
+}
+
+void VoxelVolumen::MergeFrom(const ::google::protobuf::Message& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  const VoxelVolumen* source = 
+      ::google::protobuf::internal::DynamicCastToGenerated<const VoxelVolumen>(
+          &from);
+  if (source == NULL) {
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+    MergeFrom(*source);
+  }
+}
+
+void VoxelVolumen::MergeFrom(const VoxelVolumen& from) {
+  if (GOOGLE_PREDICT_FALSE(&from == this)) MergeFromFail(__LINE__);
+  if (from._has_bits_[0 / 32] & (0xffu << (0 % 32))) {
+    if (from.has_dummy()) {
+      set_dummy(from.dummy());
+    }
+  }
+  if (from._internal_metadata_.have_unknown_fields()) {
+    mutable_unknown_fields()->MergeFrom(from.unknown_fields());
+  }
+}
+
+void VoxelVolumen::CopyFrom(const ::google::protobuf::Message& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void VoxelVolumen::CopyFrom(const VoxelVolumen& from) {
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool VoxelVolumen::IsInitialized() const {
+
+  return true;
+}
+
+void VoxelVolumen::Swap(VoxelVolumen* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void VoxelVolumen::InternalSwap(VoxelVolumen* other) {
+  std::swap(dummy_, other->dummy_);
+  std::swap(_has_bits_[0], other->_has_bits_[0]);
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+  std::swap(_cached_size_, other->_cached_size_);
+}
+
+::google::protobuf::Metadata VoxelVolumen::GetMetadata() const {
+  protobuf_AssignDescriptorsOnce();
+  ::google::protobuf::Metadata metadata;
+  metadata.descriptor = VoxelVolumen_descriptor_;
+  metadata.reflection = VoxelVolumen_reflection_;
+  return metadata;
+}
+
+#if PROTOBUF_INLINE_NOT_IN_HEADERS
+// VoxelVolumen
+
+// optional float dummy = 1;
+bool VoxelVolumen::has_dummy() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+void VoxelVolumen::set_has_dummy() {
+  _has_bits_[0] |= 0x00000001u;
+}
+void VoxelVolumen::clear_has_dummy() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+void VoxelVolumen::clear_dummy() {
+  dummy_ = 0;
+  clear_has_dummy();
+}
+ float VoxelVolumen::dummy() const {
+  // @@protoc_insertion_point(field_get:tec.proto.VoxelVolumen.dummy)
+  return dummy_;
+}
+ void VoxelVolumen::set_dummy(float value) {
+  set_has_dummy();
+  dummy_ = value;
+  // @@protoc_insertion_point(field_set:tec.proto.VoxelVolumen.dummy)
+}
+
+#endif  // PROTOBUF_INLINE_NOT_IN_HEADERS
+
+// ===================================================================
+
+#ifndef _MSC_VER
 const int Component::kRenderableFieldNumber;
 const int Component::kPositionFieldNumber;
 const int Component::kOrientationFieldNumber;
@@ -8304,9 +8590,10 @@ const int Component::kScaleFieldNumber;
 const int Component::kCollisionBodyFieldNumber;
 const int Component::kVelocityFieldNumber;
 const int Component::kAudioSourceFieldNumber;
-const int Component::kLightFieldNumber;
-const int Component::kDirlightFieldNumber;
-const int Component::kSpotlightFieldNumber;
+const int Component::kPointLightFieldNumber;
+const int Component::kDirectionalLightFieldNumber;
+const int Component::kSpotLightFieldNumber;
+const int Component::kVoxelVolumeFieldNumber;
 #endif  // !_MSC_VER
 
 Component::Component()
@@ -8325,9 +8612,10 @@ void Component::InitAsDefaultInstance() {
   Component_default_oneof_instance_->collision_body_ = const_cast< ::tec::proto::CollisionBody*>(&::tec::proto::CollisionBody::default_instance());
   Component_default_oneof_instance_->velocity_ = const_cast< ::tec::proto::Velocity*>(&::tec::proto::Velocity::default_instance());
   Component_default_oneof_instance_->audio_source_ = const_cast< ::tec::proto::AudioSource*>(&::tec::proto::AudioSource::default_instance());
-  Component_default_oneof_instance_->light_ = const_cast< ::tec::proto::Light*>(&::tec::proto::Light::default_instance());
-  Component_default_oneof_instance_->dirlight_ = const_cast< ::tec::proto::Light*>(&::tec::proto::Light::default_instance());
+  Component_default_oneof_instance_->pointlight_ = const_cast< ::tec::proto::Light*>(&::tec::proto::Light::default_instance());
+  Component_default_oneof_instance_->directionallight_ = const_cast< ::tec::proto::Light*>(&::tec::proto::Light::default_instance());
   Component_default_oneof_instance_->spotlight_ = const_cast< ::tec::proto::Light*>(&::tec::proto::Light::default_instance());
+  Component_default_oneof_instance_->voxelvolume_ = const_cast< ::tec::proto::VoxelVolumen*>(&::tec::proto::VoxelVolumen::default_instance());
 }
 
 Component::Component(const Component& from)
@@ -8420,16 +8708,20 @@ void Component::clear_component() {
       delete component_.audio_source_;
       break;
     }
-    case kLight: {
-      delete component_.light_;
+    case kPointLight: {
+      delete component_.pointlight_;
       break;
     }
-    case kDirlight: {
-      delete component_.dirlight_;
+    case kDirectionalLight: {
+      delete component_.directionallight_;
       break;
     }
-    case kSpotlight: {
+    case kSpotLight: {
       delete component_.spotlight_;
+      break;
+    }
+    case kVoxelVolume: {
+      delete component_.voxelvolume_;
       break;
     }
     case COMPONENT_NOT_SET: {
@@ -8570,42 +8862,55 @@ bool Component::MergePartialFromCodedStream(
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(82)) goto parse_light;
+        if (input->ExpectTag(82)) goto parse_pointLight;
         break;
       }
 
-      // optional .tec.proto.Light light = 10;
+      // optional .tec.proto.Light pointLight = 10;
       case 10: {
         if (tag == 82) {
-         parse_light:
+         parse_pointLight:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_light()));
+               input, mutable_pointlight()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(90)) goto parse_dirlight;
+        if (input->ExpectTag(90)) goto parse_directionalLight;
         break;
       }
 
-      // optional .tec.proto.Light dirlight = 11;
+      // optional .tec.proto.Light directionalLight = 11;
       case 11: {
         if (tag == 90) {
-         parse_dirlight:
+         parse_directionalLight:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
-               input, mutable_dirlight()));
+               input, mutable_directionallight()));
         } else {
           goto handle_unusual;
         }
-        if (input->ExpectTag(98)) goto parse_spotlight;
+        if (input->ExpectTag(98)) goto parse_spotLight;
         break;
       }
 
-      // optional .tec.proto.Light spotlight = 12;
+      // optional .tec.proto.Light spotLight = 12;
       case 12: {
         if (tag == 98) {
-         parse_spotlight:
+         parse_spotLight:
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
                input, mutable_spotlight()));
+        } else {
+          goto handle_unusual;
+        }
+        if (input->ExpectTag(106)) goto parse_voxelVolume;
+        break;
+      }
+
+      // optional .tec.proto.VoxelVolumen voxelVolume = 13;
+      case 13: {
+        if (tag == 106) {
+         parse_voxelVolume:
+          DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
+               input, mutable_voxelvolume()));
         } else {
           goto handle_unusual;
         }
@@ -8692,22 +8997,28 @@ void Component::SerializeWithCachedSizes(
       9, *component_.audio_source_, output);
   }
 
-  // optional .tec.proto.Light light = 10;
-  if (has_light()) {
+  // optional .tec.proto.Light pointLight = 10;
+  if (has_pointlight()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      10, *component_.light_, output);
+      10, *component_.pointlight_, output);
   }
 
-  // optional .tec.proto.Light dirlight = 11;
-  if (has_dirlight()) {
+  // optional .tec.proto.Light directionalLight = 11;
+  if (has_directionallight()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
-      11, *component_.dirlight_, output);
+      11, *component_.directionallight_, output);
   }
 
-  // optional .tec.proto.Light spotlight = 12;
+  // optional .tec.proto.Light spotLight = 12;
   if (has_spotlight()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
       12, *component_.spotlight_, output);
+  }
+
+  // optional .tec.proto.VoxelVolumen voxelVolume = 13;
+  if (has_voxelvolume()) {
+    ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
+      13, *component_.voxelvolume_, output);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -8783,25 +9094,32 @@ void Component::SerializeWithCachedSizes(
         9, *component_.audio_source_, target);
   }
 
-  // optional .tec.proto.Light light = 10;
-  if (has_light()) {
+  // optional .tec.proto.Light pointLight = 10;
+  if (has_pointlight()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        10, *component_.light_, target);
+        10, *component_.pointlight_, target);
   }
 
-  // optional .tec.proto.Light dirlight = 11;
-  if (has_dirlight()) {
+  // optional .tec.proto.Light directionalLight = 11;
+  if (has_directionallight()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
-        11, *component_.dirlight_, target);
+        11, *component_.directionallight_, target);
   }
 
-  // optional .tec.proto.Light spotlight = 12;
+  // optional .tec.proto.Light spotLight = 12;
   if (has_spotlight()) {
     target = ::google::protobuf::internal::WireFormatLite::
       WriteMessageNoVirtualToArray(
         12, *component_.spotlight_, target);
+  }
+
+  // optional .tec.proto.VoxelVolumen voxelVolume = 13;
+  if (has_voxelvolume()) {
+    target = ::google::protobuf::internal::WireFormatLite::
+      WriteMessageNoVirtualToArray(
+        13, *component_.voxelvolume_, target);
   }
 
   if (_internal_metadata_.have_unknown_fields()) {
@@ -8879,25 +9197,32 @@ int Component::ByteSize() const {
           *component_.audio_source_);
       break;
     }
-    // optional .tec.proto.Light light = 10;
-    case kLight: {
+    // optional .tec.proto.Light pointLight = 10;
+    case kPointLight: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *component_.light_);
+          *component_.pointlight_);
       break;
     }
-    // optional .tec.proto.Light dirlight = 11;
-    case kDirlight: {
+    // optional .tec.proto.Light directionalLight = 11;
+    case kDirectionalLight: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
-          *component_.dirlight_);
+          *component_.directionallight_);
       break;
     }
-    // optional .tec.proto.Light spotlight = 12;
-    case kSpotlight: {
+    // optional .tec.proto.Light spotLight = 12;
+    case kSpotLight: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
           *component_.spotlight_);
+      break;
+    }
+    // optional .tec.proto.VoxelVolumen voxelVolume = 13;
+    case kVoxelVolume: {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::MessageSizeNoVirtual(
+          *component_.voxelvolume_);
       break;
     }
     case COMPONENT_NOT_SET: {
@@ -8966,16 +9291,20 @@ void Component::MergeFrom(const Component& from) {
       mutable_audio_source()->::tec::proto::AudioSource::MergeFrom(from.audio_source());
       break;
     }
-    case kLight: {
-      mutable_light()->::tec::proto::Light::MergeFrom(from.light());
+    case kPointLight: {
+      mutable_pointlight()->::tec::proto::Light::MergeFrom(from.pointlight());
       break;
     }
-    case kDirlight: {
-      mutable_dirlight()->::tec::proto::Light::MergeFrom(from.dirlight());
+    case kDirectionalLight: {
+      mutable_directionallight()->::tec::proto::Light::MergeFrom(from.directionallight());
       break;
     }
-    case kSpotlight: {
+    case kSpotLight: {
       mutable_spotlight()->::tec::proto::Light::MergeFrom(from.spotlight());
+      break;
+    }
+    case kVoxelVolume: {
+      mutable_voxelvolume()->::tec::proto::VoxelVolumen::MergeFrom(from.voxelvolume());
       break;
     }
     case COMPONENT_NOT_SET: {
@@ -9447,104 +9776,104 @@ void Component::clear_audio_source() {
   // @@protoc_insertion_point(field_set_allocated:tec.proto.Component.audio_source)
 }
 
-// optional .tec.proto.Light light = 10;
-bool Component::has_light() const {
-  return component_case() == kLight;
+// optional .tec.proto.Light pointLight = 10;
+bool Component::has_pointlight() const {
+  return component_case() == kPointLight;
 }
-void Component::set_has_light() {
-  _oneof_case_[0] = kLight;
+void Component::set_has_pointlight() {
+  _oneof_case_[0] = kPointLight;
 }
-void Component::clear_light() {
-  if (has_light()) {
-    delete component_.light_;
+void Component::clear_pointlight() {
+  if (has_pointlight()) {
+    delete component_.pointlight_;
     clear_has_component();
   }
 }
- const ::tec::proto::Light& Component::light() const {
-  // @@protoc_insertion_point(field_get:tec.proto.Component.light)
-  return has_light() ? *component_.light_
+ const ::tec::proto::Light& Component::pointlight() const {
+  // @@protoc_insertion_point(field_get:tec.proto.Component.pointLight)
+  return has_pointlight() ? *component_.pointlight_
                       : ::tec::proto::Light::default_instance();
 }
- ::tec::proto::Light* Component::mutable_light() {
-  if (!has_light()) {
+ ::tec::proto::Light* Component::mutable_pointlight() {
+  if (!has_pointlight()) {
     clear_component();
-    set_has_light();
-    component_.light_ = new ::tec::proto::Light;
+    set_has_pointlight();
+    component_.pointlight_ = new ::tec::proto::Light;
   }
-  // @@protoc_insertion_point(field_mutable:tec.proto.Component.light)
-  return component_.light_;
+  // @@protoc_insertion_point(field_mutable:tec.proto.Component.pointLight)
+  return component_.pointlight_;
 }
- ::tec::proto::Light* Component::release_light() {
-  if (has_light()) {
+ ::tec::proto::Light* Component::release_pointlight() {
+  if (has_pointlight()) {
     clear_has_component();
-    ::tec::proto::Light* temp = component_.light_;
-    component_.light_ = NULL;
+    ::tec::proto::Light* temp = component_.pointlight_;
+    component_.pointlight_ = NULL;
     return temp;
   } else {
     return NULL;
   }
 }
- void Component::set_allocated_light(::tec::proto::Light* light) {
+ void Component::set_allocated_pointlight(::tec::proto::Light* pointlight) {
   clear_component();
-  if (light) {
-    set_has_light();
-    component_.light_ = light;
+  if (pointlight) {
+    set_has_pointlight();
+    component_.pointlight_ = pointlight;
   }
-  // @@protoc_insertion_point(field_set_allocated:tec.proto.Component.light)
+  // @@protoc_insertion_point(field_set_allocated:tec.proto.Component.pointLight)
 }
 
-// optional .tec.proto.Light dirlight = 11;
-bool Component::has_dirlight() const {
-  return component_case() == kDirlight;
+// optional .tec.proto.Light directionalLight = 11;
+bool Component::has_directionallight() const {
+  return component_case() == kDirectionalLight;
 }
-void Component::set_has_dirlight() {
-  _oneof_case_[0] = kDirlight;
+void Component::set_has_directionallight() {
+  _oneof_case_[0] = kDirectionalLight;
 }
-void Component::clear_dirlight() {
-  if (has_dirlight()) {
-    delete component_.dirlight_;
+void Component::clear_directionallight() {
+  if (has_directionallight()) {
+    delete component_.directionallight_;
     clear_has_component();
   }
 }
- const ::tec::proto::Light& Component::dirlight() const {
-  // @@protoc_insertion_point(field_get:tec.proto.Component.dirlight)
-  return has_dirlight() ? *component_.dirlight_
+ const ::tec::proto::Light& Component::directionallight() const {
+  // @@protoc_insertion_point(field_get:tec.proto.Component.directionalLight)
+  return has_directionallight() ? *component_.directionallight_
                       : ::tec::proto::Light::default_instance();
 }
- ::tec::proto::Light* Component::mutable_dirlight() {
-  if (!has_dirlight()) {
+ ::tec::proto::Light* Component::mutable_directionallight() {
+  if (!has_directionallight()) {
     clear_component();
-    set_has_dirlight();
-    component_.dirlight_ = new ::tec::proto::Light;
+    set_has_directionallight();
+    component_.directionallight_ = new ::tec::proto::Light;
   }
-  // @@protoc_insertion_point(field_mutable:tec.proto.Component.dirlight)
-  return component_.dirlight_;
+  // @@protoc_insertion_point(field_mutable:tec.proto.Component.directionalLight)
+  return component_.directionallight_;
 }
- ::tec::proto::Light* Component::release_dirlight() {
-  if (has_dirlight()) {
+ ::tec::proto::Light* Component::release_directionallight() {
+  if (has_directionallight()) {
     clear_has_component();
-    ::tec::proto::Light* temp = component_.dirlight_;
-    component_.dirlight_ = NULL;
+    ::tec::proto::Light* temp = component_.directionallight_;
+    component_.directionallight_ = NULL;
     return temp;
   } else {
     return NULL;
   }
 }
- void Component::set_allocated_dirlight(::tec::proto::Light* dirlight) {
+ void Component::set_allocated_directionallight(::tec::proto::Light* directionallight) {
   clear_component();
-  if (dirlight) {
-    set_has_dirlight();
-    component_.dirlight_ = dirlight;
+  if (directionallight) {
+    set_has_directionallight();
+    component_.directionallight_ = directionallight;
   }
-  // @@protoc_insertion_point(field_set_allocated:tec.proto.Component.dirlight)
+  // @@protoc_insertion_point(field_set_allocated:tec.proto.Component.directionalLight)
 }
 
-// optional .tec.proto.Light spotlight = 12;
+// optional .tec.proto.Light spotLight = 12;
 bool Component::has_spotlight() const {
-  return component_case() == kSpotlight;
+  return component_case() == kSpotLight;
 }
 void Component::set_has_spotlight() {
-  _oneof_case_[0] = kSpotlight;
+  _oneof_case_[0] = kSpotLight;
 }
 void Component::clear_spotlight() {
   if (has_spotlight()) {
@@ -9553,7 +9882,7 @@ void Component::clear_spotlight() {
   }
 }
  const ::tec::proto::Light& Component::spotlight() const {
-  // @@protoc_insertion_point(field_get:tec.proto.Component.spotlight)
+  // @@protoc_insertion_point(field_get:tec.proto.Component.spotLight)
   return has_spotlight() ? *component_.spotlight_
                       : ::tec::proto::Light::default_instance();
 }
@@ -9563,7 +9892,7 @@ void Component::clear_spotlight() {
     set_has_spotlight();
     component_.spotlight_ = new ::tec::proto::Light;
   }
-  // @@protoc_insertion_point(field_mutable:tec.proto.Component.spotlight)
+  // @@protoc_insertion_point(field_mutable:tec.proto.Component.spotLight)
   return component_.spotlight_;
 }
  ::tec::proto::Light* Component::release_spotlight() {
@@ -9582,7 +9911,53 @@ void Component::clear_spotlight() {
     set_has_spotlight();
     component_.spotlight_ = spotlight;
   }
-  // @@protoc_insertion_point(field_set_allocated:tec.proto.Component.spotlight)
+  // @@protoc_insertion_point(field_set_allocated:tec.proto.Component.spotLight)
+}
+
+// optional .tec.proto.VoxelVolumen voxelVolume = 13;
+bool Component::has_voxelvolume() const {
+  return component_case() == kVoxelVolume;
+}
+void Component::set_has_voxelvolume() {
+  _oneof_case_[0] = kVoxelVolume;
+}
+void Component::clear_voxelvolume() {
+  if (has_voxelvolume()) {
+    delete component_.voxelvolume_;
+    clear_has_component();
+  }
+}
+ const ::tec::proto::VoxelVolumen& Component::voxelvolume() const {
+  // @@protoc_insertion_point(field_get:tec.proto.Component.voxelVolume)
+  return has_voxelvolume() ? *component_.voxelvolume_
+                      : ::tec::proto::VoxelVolumen::default_instance();
+}
+ ::tec::proto::VoxelVolumen* Component::mutable_voxelvolume() {
+  if (!has_voxelvolume()) {
+    clear_component();
+    set_has_voxelvolume();
+    component_.voxelvolume_ = new ::tec::proto::VoxelVolumen;
+  }
+  // @@protoc_insertion_point(field_mutable:tec.proto.Component.voxelVolume)
+  return component_.voxelvolume_;
+}
+ ::tec::proto::VoxelVolumen* Component::release_voxelvolume() {
+  if (has_voxelvolume()) {
+    clear_has_component();
+    ::tec::proto::VoxelVolumen* temp = component_.voxelvolume_;
+    component_.voxelvolume_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
+}
+ void Component::set_allocated_voxelvolume(::tec::proto::VoxelVolumen* voxelvolume) {
+  clear_component();
+  if (voxelvolume) {
+    set_has_voxelvolume();
+    component_.voxelvolume_ = voxelvolume;
+  }
+  // @@protoc_insertion_point(field_set_allocated:tec.proto.Component.voxelVolume)
 }
 
 bool Component::has_component() const {

--- a/proto/components.pb.h
+++ b/proto/components.pb.h
@@ -54,6 +54,7 @@ class AudioSource;
 class Light;
 class Light_Attenuation;
 class Light_Direction;
+class VoxelVolumen;
 class Component;
 class Entity;
 class EntityFileList;
@@ -2064,6 +2065,95 @@ class Light : public ::google::protobuf::Message {
 };
 // -------------------------------------------------------------------
 
+class VoxelVolumen : public ::google::protobuf::Message {
+ public:
+  VoxelVolumen();
+  virtual ~VoxelVolumen();
+
+  VoxelVolumen(const VoxelVolumen& from);
+
+  inline VoxelVolumen& operator=(const VoxelVolumen& from) {
+    CopyFrom(from);
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const {
+    return _internal_metadata_.unknown_fields();
+  }
+
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields() {
+    return _internal_metadata_.mutable_unknown_fields();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const VoxelVolumen& default_instance();
+
+  void Swap(VoxelVolumen* other);
+
+  // implements Message ----------------------------------------------
+
+  inline VoxelVolumen* New() const { return New(NULL); }
+
+  VoxelVolumen* New(::google::protobuf::Arena* arena) const;
+  void CopyFrom(const ::google::protobuf::Message& from);
+  void MergeFrom(const ::google::protobuf::Message& from);
+  void CopyFrom(const VoxelVolumen& from);
+  void MergeFrom(const VoxelVolumen& from);
+  void Clear();
+  bool IsInitialized() const;
+
+  int ByteSize() const;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input);
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const;
+  ::google::protobuf::uint8* SerializeWithCachedSizesToArray(::google::protobuf::uint8* output) const;
+  int GetCachedSize() const { return _cached_size_; }
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const;
+  void InternalSwap(VoxelVolumen* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return _internal_metadata_.arena();
+  }
+  inline void* MaybeArenaPtr() const {
+    return _internal_metadata_.raw_arena_ptr();
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // optional float dummy = 1;
+  bool has_dummy() const;
+  void clear_dummy();
+  static const int kDummyFieldNumber = 1;
+  float dummy() const;
+  void set_dummy(float value);
+
+  // @@protoc_insertion_point(class_scope:tec.proto.VoxelVolumen)
+ private:
+  inline void set_has_dummy();
+  inline void clear_has_dummy();
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::uint32 _has_bits_[1];
+  mutable int _cached_size_;
+  float dummy_;
+  friend void  protobuf_AddDesc_components_2eproto();
+  friend void protobuf_AssignDesc_components_2eproto();
+  friend void protobuf_ShutdownFile_components_2eproto();
+
+  void InitAsDefaultInstance();
+  static VoxelVolumen* default_instance_;
+};
+// -------------------------------------------------------------------
+
 class Component : public ::google::protobuf::Message {
  public:
   Component();
@@ -2097,9 +2187,10 @@ class Component : public ::google::protobuf::Message {
     kCollisionBody = 7,
     kVelocity = 8,
     kAudioSource = 9,
-    kLight = 10,
-    kDirlight = 11,
-    kSpotlight = 12,
+    kPointLight = 10,
+    kDirectionalLight = 11,
+    kSpotLight = 12,
+    kVoxelVolume = 13,
     COMPONENT_NOT_SET = 0,
   };
 
@@ -2225,32 +2316,41 @@ class Component : public ::google::protobuf::Message {
   ::tec::proto::AudioSource* release_audio_source();
   void set_allocated_audio_source(::tec::proto::AudioSource* audio_source);
 
-  // optional .tec.proto.Light light = 10;
-  bool has_light() const;
-  void clear_light();
-  static const int kLightFieldNumber = 10;
-  const ::tec::proto::Light& light() const;
-  ::tec::proto::Light* mutable_light();
-  ::tec::proto::Light* release_light();
-  void set_allocated_light(::tec::proto::Light* light);
+  // optional .tec.proto.Light pointLight = 10;
+  bool has_pointlight() const;
+  void clear_pointlight();
+  static const int kPointLightFieldNumber = 10;
+  const ::tec::proto::Light& pointlight() const;
+  ::tec::proto::Light* mutable_pointlight();
+  ::tec::proto::Light* release_pointlight();
+  void set_allocated_pointlight(::tec::proto::Light* pointlight);
 
-  // optional .tec.proto.Light dirlight = 11;
-  bool has_dirlight() const;
-  void clear_dirlight();
-  static const int kDirlightFieldNumber = 11;
-  const ::tec::proto::Light& dirlight() const;
-  ::tec::proto::Light* mutable_dirlight();
-  ::tec::proto::Light* release_dirlight();
-  void set_allocated_dirlight(::tec::proto::Light* dirlight);
+  // optional .tec.proto.Light directionalLight = 11;
+  bool has_directionallight() const;
+  void clear_directionallight();
+  static const int kDirectionalLightFieldNumber = 11;
+  const ::tec::proto::Light& directionallight() const;
+  ::tec::proto::Light* mutable_directionallight();
+  ::tec::proto::Light* release_directionallight();
+  void set_allocated_directionallight(::tec::proto::Light* directionallight);
 
-  // optional .tec.proto.Light spotlight = 12;
+  // optional .tec.proto.Light spotLight = 12;
   bool has_spotlight() const;
   void clear_spotlight();
-  static const int kSpotlightFieldNumber = 12;
+  static const int kSpotLightFieldNumber = 12;
   const ::tec::proto::Light& spotlight() const;
   ::tec::proto::Light* mutable_spotlight();
   ::tec::proto::Light* release_spotlight();
   void set_allocated_spotlight(::tec::proto::Light* spotlight);
+
+  // optional .tec.proto.VoxelVolumen voxelVolume = 13;
+  bool has_voxelvolume() const;
+  void clear_voxelvolume();
+  static const int kVoxelVolumeFieldNumber = 13;
+  const ::tec::proto::VoxelVolumen& voxelvolume() const;
+  ::tec::proto::VoxelVolumen* mutable_voxelvolume();
+  ::tec::proto::VoxelVolumen* release_voxelvolume();
+  void set_allocated_voxelvolume(::tec::proto::VoxelVolumen* voxelvolume);
 
   ComponentCase component_case() const;
   // @@protoc_insertion_point(class_scope:tec.proto.Component)
@@ -2264,9 +2364,10 @@ class Component : public ::google::protobuf::Message {
   inline void set_has_collision_body();
   inline void set_has_velocity();
   inline void set_has_audio_source();
-  inline void set_has_light();
-  inline void set_has_dirlight();
+  inline void set_has_pointlight();
+  inline void set_has_directionallight();
   inline void set_has_spotlight();
+  inline void set_has_voxelvolume();
 
   inline bool has_component() const;
   void clear_component();
@@ -2286,9 +2387,10 @@ class Component : public ::google::protobuf::Message {
     ::tec::proto::CollisionBody* collision_body_;
     ::tec::proto::Velocity* velocity_;
     ::tec::proto::AudioSource* audio_source_;
-    ::tec::proto::Light* light_;
-    ::tec::proto::Light* dirlight_;
+    ::tec::proto::Light* pointlight_;
+    ::tec::proto::Light* directionallight_;
     ::tec::proto::Light* spotlight_;
+    ::tec::proto::VoxelVolumen* voxelvolume_;
   } component_;
   ::google::protobuf::uint32 _oneof_case_[1];
 
@@ -4254,6 +4356,34 @@ inline void Light::set_allocated_direction(::tec::proto::Light_Direction* direct
 
 // -------------------------------------------------------------------
 
+// VoxelVolumen
+
+// optional float dummy = 1;
+inline bool VoxelVolumen::has_dummy() const {
+  return (_has_bits_[0] & 0x00000001u) != 0;
+}
+inline void VoxelVolumen::set_has_dummy() {
+  _has_bits_[0] |= 0x00000001u;
+}
+inline void VoxelVolumen::clear_has_dummy() {
+  _has_bits_[0] &= ~0x00000001u;
+}
+inline void VoxelVolumen::clear_dummy() {
+  dummy_ = 0;
+  clear_has_dummy();
+}
+inline float VoxelVolumen::dummy() const {
+  // @@protoc_insertion_point(field_get:tec.proto.VoxelVolumen.dummy)
+  return dummy_;
+}
+inline void VoxelVolumen::set_dummy(float value) {
+  set_has_dummy();
+  dummy_ = value;
+  // @@protoc_insertion_point(field_set:tec.proto.VoxelVolumen.dummy)
+}
+
+// -------------------------------------------------------------------
+
 // Component
 
 // optional .tec.proto.Renderable renderable = 1;
@@ -4670,104 +4800,104 @@ inline void Component::set_allocated_audio_source(::tec::proto::AudioSource* aud
   // @@protoc_insertion_point(field_set_allocated:tec.proto.Component.audio_source)
 }
 
-// optional .tec.proto.Light light = 10;
-inline bool Component::has_light() const {
-  return component_case() == kLight;
+// optional .tec.proto.Light pointLight = 10;
+inline bool Component::has_pointlight() const {
+  return component_case() == kPointLight;
 }
-inline void Component::set_has_light() {
-  _oneof_case_[0] = kLight;
+inline void Component::set_has_pointlight() {
+  _oneof_case_[0] = kPointLight;
 }
-inline void Component::clear_light() {
-  if (has_light()) {
-    delete component_.light_;
+inline void Component::clear_pointlight() {
+  if (has_pointlight()) {
+    delete component_.pointlight_;
     clear_has_component();
   }
 }
-inline const ::tec::proto::Light& Component::light() const {
-  // @@protoc_insertion_point(field_get:tec.proto.Component.light)
-  return has_light() ? *component_.light_
+inline const ::tec::proto::Light& Component::pointlight() const {
+  // @@protoc_insertion_point(field_get:tec.proto.Component.pointLight)
+  return has_pointlight() ? *component_.pointlight_
                       : ::tec::proto::Light::default_instance();
 }
-inline ::tec::proto::Light* Component::mutable_light() {
-  if (!has_light()) {
+inline ::tec::proto::Light* Component::mutable_pointlight() {
+  if (!has_pointlight()) {
     clear_component();
-    set_has_light();
-    component_.light_ = new ::tec::proto::Light;
+    set_has_pointlight();
+    component_.pointlight_ = new ::tec::proto::Light;
   }
-  // @@protoc_insertion_point(field_mutable:tec.proto.Component.light)
-  return component_.light_;
+  // @@protoc_insertion_point(field_mutable:tec.proto.Component.pointLight)
+  return component_.pointlight_;
 }
-inline ::tec::proto::Light* Component::release_light() {
-  if (has_light()) {
+inline ::tec::proto::Light* Component::release_pointlight() {
+  if (has_pointlight()) {
     clear_has_component();
-    ::tec::proto::Light* temp = component_.light_;
-    component_.light_ = NULL;
+    ::tec::proto::Light* temp = component_.pointlight_;
+    component_.pointlight_ = NULL;
     return temp;
   } else {
     return NULL;
   }
 }
-inline void Component::set_allocated_light(::tec::proto::Light* light) {
+inline void Component::set_allocated_pointlight(::tec::proto::Light* pointlight) {
   clear_component();
-  if (light) {
-    set_has_light();
-    component_.light_ = light;
+  if (pointlight) {
+    set_has_pointlight();
+    component_.pointlight_ = pointlight;
   }
-  // @@protoc_insertion_point(field_set_allocated:tec.proto.Component.light)
+  // @@protoc_insertion_point(field_set_allocated:tec.proto.Component.pointLight)
 }
 
-// optional .tec.proto.Light dirlight = 11;
-inline bool Component::has_dirlight() const {
-  return component_case() == kDirlight;
+// optional .tec.proto.Light directionalLight = 11;
+inline bool Component::has_directionallight() const {
+  return component_case() == kDirectionalLight;
 }
-inline void Component::set_has_dirlight() {
-  _oneof_case_[0] = kDirlight;
+inline void Component::set_has_directionallight() {
+  _oneof_case_[0] = kDirectionalLight;
 }
-inline void Component::clear_dirlight() {
-  if (has_dirlight()) {
-    delete component_.dirlight_;
+inline void Component::clear_directionallight() {
+  if (has_directionallight()) {
+    delete component_.directionallight_;
     clear_has_component();
   }
 }
-inline const ::tec::proto::Light& Component::dirlight() const {
-  // @@protoc_insertion_point(field_get:tec.proto.Component.dirlight)
-  return has_dirlight() ? *component_.dirlight_
+inline const ::tec::proto::Light& Component::directionallight() const {
+  // @@protoc_insertion_point(field_get:tec.proto.Component.directionalLight)
+  return has_directionallight() ? *component_.directionallight_
                       : ::tec::proto::Light::default_instance();
 }
-inline ::tec::proto::Light* Component::mutable_dirlight() {
-  if (!has_dirlight()) {
+inline ::tec::proto::Light* Component::mutable_directionallight() {
+  if (!has_directionallight()) {
     clear_component();
-    set_has_dirlight();
-    component_.dirlight_ = new ::tec::proto::Light;
+    set_has_directionallight();
+    component_.directionallight_ = new ::tec::proto::Light;
   }
-  // @@protoc_insertion_point(field_mutable:tec.proto.Component.dirlight)
-  return component_.dirlight_;
+  // @@protoc_insertion_point(field_mutable:tec.proto.Component.directionalLight)
+  return component_.directionallight_;
 }
-inline ::tec::proto::Light* Component::release_dirlight() {
-  if (has_dirlight()) {
+inline ::tec::proto::Light* Component::release_directionallight() {
+  if (has_directionallight()) {
     clear_has_component();
-    ::tec::proto::Light* temp = component_.dirlight_;
-    component_.dirlight_ = NULL;
+    ::tec::proto::Light* temp = component_.directionallight_;
+    component_.directionallight_ = NULL;
     return temp;
   } else {
     return NULL;
   }
 }
-inline void Component::set_allocated_dirlight(::tec::proto::Light* dirlight) {
+inline void Component::set_allocated_directionallight(::tec::proto::Light* directionallight) {
   clear_component();
-  if (dirlight) {
-    set_has_dirlight();
-    component_.dirlight_ = dirlight;
+  if (directionallight) {
+    set_has_directionallight();
+    component_.directionallight_ = directionallight;
   }
-  // @@protoc_insertion_point(field_set_allocated:tec.proto.Component.dirlight)
+  // @@protoc_insertion_point(field_set_allocated:tec.proto.Component.directionalLight)
 }
 
-// optional .tec.proto.Light spotlight = 12;
+// optional .tec.proto.Light spotLight = 12;
 inline bool Component::has_spotlight() const {
-  return component_case() == kSpotlight;
+  return component_case() == kSpotLight;
 }
 inline void Component::set_has_spotlight() {
-  _oneof_case_[0] = kSpotlight;
+  _oneof_case_[0] = kSpotLight;
 }
 inline void Component::clear_spotlight() {
   if (has_spotlight()) {
@@ -4776,7 +4906,7 @@ inline void Component::clear_spotlight() {
   }
 }
 inline const ::tec::proto::Light& Component::spotlight() const {
-  // @@protoc_insertion_point(field_get:tec.proto.Component.spotlight)
+  // @@protoc_insertion_point(field_get:tec.proto.Component.spotLight)
   return has_spotlight() ? *component_.spotlight_
                       : ::tec::proto::Light::default_instance();
 }
@@ -4786,7 +4916,7 @@ inline ::tec::proto::Light* Component::mutable_spotlight() {
     set_has_spotlight();
     component_.spotlight_ = new ::tec::proto::Light;
   }
-  // @@protoc_insertion_point(field_mutable:tec.proto.Component.spotlight)
+  // @@protoc_insertion_point(field_mutable:tec.proto.Component.spotLight)
   return component_.spotlight_;
 }
 inline ::tec::proto::Light* Component::release_spotlight() {
@@ -4805,7 +4935,53 @@ inline void Component::set_allocated_spotlight(::tec::proto::Light* spotlight) {
     set_has_spotlight();
     component_.spotlight_ = spotlight;
   }
-  // @@protoc_insertion_point(field_set_allocated:tec.proto.Component.spotlight)
+  // @@protoc_insertion_point(field_set_allocated:tec.proto.Component.spotLight)
+}
+
+// optional .tec.proto.VoxelVolumen voxelVolume = 13;
+inline bool Component::has_voxelvolume() const {
+  return component_case() == kVoxelVolume;
+}
+inline void Component::set_has_voxelvolume() {
+  _oneof_case_[0] = kVoxelVolume;
+}
+inline void Component::clear_voxelvolume() {
+  if (has_voxelvolume()) {
+    delete component_.voxelvolume_;
+    clear_has_component();
+  }
+}
+inline const ::tec::proto::VoxelVolumen& Component::voxelvolume() const {
+  // @@protoc_insertion_point(field_get:tec.proto.Component.voxelVolume)
+  return has_voxelvolume() ? *component_.voxelvolume_
+                      : ::tec::proto::VoxelVolumen::default_instance();
+}
+inline ::tec::proto::VoxelVolumen* Component::mutable_voxelvolume() {
+  if (!has_voxelvolume()) {
+    clear_component();
+    set_has_voxelvolume();
+    component_.voxelvolume_ = new ::tec::proto::VoxelVolumen;
+  }
+  // @@protoc_insertion_point(field_mutable:tec.proto.Component.voxelVolume)
+  return component_.voxelvolume_;
+}
+inline ::tec::proto::VoxelVolumen* Component::release_voxelvolume() {
+  if (has_voxelvolume()) {
+    clear_has_component();
+    ::tec::proto::VoxelVolumen* temp = component_.voxelvolume_;
+    component_.voxelvolume_ = NULL;
+    return temp;
+  } else {
+    return NULL;
+  }
+}
+inline void Component::set_allocated_voxelvolume(::tec::proto::VoxelVolumen* voxelvolume) {
+  clear_component();
+  if (voxelvolume) {
+    set_has_voxelvolume();
+    component_.voxelvolume_ = voxelvolume;
+  }
+  // @@protoc_insertion_point(field_set_allocated:tec.proto.Component.voxelVolume)
 }
 
 inline bool Component::has_component() const {
@@ -4934,6 +5110,8 @@ EntityFileList::mutable_entity_file_list() {
 }
 
 #endif  // !PROTOBUF_INLINE_NOT_IN_HEADERS
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/proto/components.proto
+++ b/proto/components.proto
@@ -107,8 +107,13 @@ message Light {
 	optional Direction direction = 8;
 }
 
+message VoxelVolumen {
+	optional float dummy = 1; // WIP
+}
+
 message Component {
 	oneof component {
+		// keep name the same that the struct/class of the component!
 		Renderable renderable = 1;
 		Position position = 2;
 		Orientation orientation = 3;
@@ -118,9 +123,10 @@ message Component {
 		CollisionBody collision_body = 7;
 		Velocity velocity = 8;
 		AudioSource audio_source = 9;
-		Light light = 10;
-		Light dirlight = 11;
-		Light spotlight = 12;
+		Light pointLight = 10;
+		Light directionalLight = 11;
+		Light spotLight = 12;
+		VoxelVolumen voxelVolume = 13;
 	}
 }
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -1,0 +1,34 @@
+/**
+ * @file types.cpp
+ *
+ * Here defines the values of string typename of components, on runtime (ie when we can't use template T parameters )
+ */
+
+#include "types.hpp"
+
+namespace tec {
+	
+// Tool to build the runtime name storage of components
+#define MAKE_MAPPAIR(a) \
+{ GetTypeID<a>(), GetTypeName<a>() }
+
+	/// Maps on runtime the Type ID with the name
+	const std::unordered_map<tid, const char*> TypeName = {
+		MAKE_MAPPAIR(void) ,
+		MAKE_MAPPAIR(Renderable) ,
+		MAKE_MAPPAIR(Position) ,
+		MAKE_MAPPAIR(Orientation) ,
+		MAKE_MAPPAIR(View) ,
+		MAKE_MAPPAIR(Animation) ,
+		MAKE_MAPPAIR(Scale) ,
+		MAKE_MAPPAIR(CollisionBody) ,
+		MAKE_MAPPAIR(AudioSource) ,
+		MAKE_MAPPAIR(PointLight) ,
+		MAKE_MAPPAIR(DirectionalLight) ,
+		// SpotLight
+		MAKE_MAPPAIR(VoxelVolume)
+	};
+
+#undef MAKE_MAPPAIR
+}
+


### PR DESCRIPTION
We use proto::Component enum values as TypeID value. This make more easy to
follow the track to all, and make more simple to register new component types.
The price is that .protfile component name must be the same that the struct/class
name.

Also, we now have a runtime map of type ID to const char* . This is **necesarry
to map some stuff to Lua**.