### PR TITLE
Build fix for clang and gcc 6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,7 +272,7 @@ ENDIF (APPLE)
 # define all required external libraries
 # the use of raw names allows MSVC to pick-up debug version automatically
 SET(CMAKE_CXX_STANDARD 14)
-SET(CMAKE_CXX_STANDARD_REQUIRED 14)
+SET(CMAKE_CXX_STANDARD_REQUIRED ON)
 IF (NOT ${BUILD_DEPS_FIRST})
   MESSAGE("All dependencies found now building tec.")
   # Add the virtual computer

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Building takes a few steps to get everything set up for the first build.
 2. `mkdir build/` in to root directory
 3. `cd build/`
 4. Follow platform specific instructions 
-  1. Linux (G++ 3.9 or CLang 3.7)
+  1. Linux (G++ 5 or CLang 3.8)
      - If you have Bullet, GLEW and OpenAL dev libs installed : 
        1. `cmake ..` in the build directory
        2. `make TEC` in the build directory

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -127,7 +127,7 @@ int main(int argc, char* argv[]) {
 	tec::FPSController* camera_controller = nullptr;
 	gui.AddWindowDrawFunction("connect_window", [&] () {
 		ImGui::SetNextWindowPosCenter();
-		ImGui::Begin("Connect to Server", false, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse);
+		ImGui::Begin("Connect to Server", NULL, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse);
 
 		static int octets[4] = {127, 0, 0, 1};
 
@@ -261,7 +261,7 @@ int main(int argc, char* argv[]) {
 	gui.ShowWindow("main_menu");
 	gui.AddWindowDrawFunction("ping_times", [&connection] () {
 		ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0, 0, 0, 0));
-		ImGui::Begin("ping_times", false, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoInputs);
+		ImGui::Begin("ping_times", NULL, ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoInputs);
 		static float arr[10];
 		std::list<tec::networking::ping_time_t> recent_pings = connection.GetRecentPings();
 		std::size_t i = 0;

--- a/src/resources/md5mesh.cpp
+++ b/src/resources/md5mesh.cpp
@@ -371,7 +371,7 @@ namespace tec {
 				objgroup->indices.push_back(int_mesh.tris[j].verts[1]);
 				objgroup->indices.push_back(int_mesh.tris[j].verts[2]);
 			}
-			MaterialGroup mat_group = {0, objgroup->indices.size(), material_name};
+			MaterialGroup mat_group = {0, static_cast<unsigned int>(objgroup->indices.size()), material_name};
 			mat_group.textures.push_back(int_mesh.shader);
 			objgroup->material_groups.push_back(std::move(mat_group));
 		}

--- a/src/voxelvolume.cpp
+++ b/src/voxelvolume.cpp
@@ -197,7 +197,7 @@ namespace tec {
 				}
 			}
 			if (objgroup->material_groups.size() == 0) {
-				MaterialGroup mat_group = {0, objgroup->indices.size(), "voxel"};
+				MaterialGroup mat_group = {0, static_cast<unsigned int>(objgroup->indices.size()), "voxel"};
 				mat_group.textures.push_back("metal_wall");
 				objgroup->material_groups.push_back(std::move(mat_group));
 			}


### PR DESCRIPTION
This pull request fixes the build for clang (tested with 3.8), and changes CMakeLists.txt to actually check for the right C++ standard (c++14). Also the readme has been updated to tell the updated compiler requirements. Should fix #74 and #76.