### PR TITLE
General cleanup for warnings and style

### DIFF
--- a/client/gui/console.cpp
+++ b/client/gui/console.cpp
@@ -59,7 +59,7 @@ namespace tec {
 
 	void Console::Println(const std::string& str, ImVec4 color) {
 		{
-			std::lock_guard<std::mutex> lock(input_mutex);
+			std::lock_guard<std::mutex> lg(input_mutex);
 			if (buf->full()) {
 				buf->pop_back();
 			}
@@ -70,7 +70,7 @@ namespace tec {
 
 	void Console::Println(const char* cstr, ImVec4 color) {
 		{
-			std::lock_guard<std::mutex> lock(input_mutex);
+			std::lock_guard<std::mutex> lg(input_mutex);
 			if (buf->full()) {
 				buf->pop_back();
 			}
@@ -88,7 +88,7 @@ namespace tec {
 		va_end(args);
 
 		{
-			std::lock_guard<std::mutex> lock(input_mutex);
+			std::lock_guard<std::mutex> lg(input_mutex);
 			if (buf->full()) {
 				buf->pop_back();
 			}

--- a/client/gui/console.hpp
+++ b/client/gui/console.hpp
@@ -68,8 +68,9 @@ namespace tec {
 
 		std::map<std::string, std::tuple<std::function<void(const char*)>, std::string>> commands; /// Storage of commands and help info
 			
+		using EventQueue<WindowResizedEvent>::On;
+		using EventQueue<KeyboardEvent>::On;
 		void On(std::shared_ptr<WindowResizedEvent> data);
-
 		void On(std::shared_ptr<KeyboardEvent> data);
 	};
 
@@ -81,15 +82,15 @@ namespace tec {
 			// SPDLog sink interface
 			void log(const spdlog::details::log_msg& msg) override;
 			
-			void flush() {};
+			void flush() override {}
 
 			void set_pattern(const std::string& pattern) final {
-				std::lock_guard<std::mutex> lock(mutex_);
+				std::lock_guard<std::mutex> lg(mutex_);
 				set_pattern_(pattern);
 			}
 
 			void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) final {
-				std::lock_guard<std::mutex> lock(mutex_);
+				std::lock_guard<std::mutex> lg(mutex_);
 				set_formatter_(std::move(sink_formatter));
 			}
 		private:

--- a/client/imgui-system.cpp
+++ b/client/imgui-system.cpp
@@ -158,7 +158,7 @@ namespace tec {
 			}
 									});
 		this->ShowWindow("active_entity");
-		this->AddWindowDrawFunction("main_menu", [os, connection, this] () {
+		this->AddWindowDrawFunction("main_menu", [connection, this] () {
 			if (ImGui::BeginMainMenuBar()) {
 				if (ImGui::BeginMenu("Connect")) {
 					bool visible = this->IsWindowVisible("connect_window");

--- a/client/imgui-system.hpp
+++ b/client/imgui-system.hpp
@@ -9,7 +9,7 @@
 #include <functional>
 
 #ifdef __APPLE__
-#include <OpenGL/gl3.h>
+#define GLFW_INCLUDE_GLCOREARB
 #else
 #include <GL/glew.h>
 #ifndef __unix
@@ -34,11 +34,11 @@ namespace tec {
 	}
 
 	class IMGUISystem :
-		public CommandQueue < IMGUISystem >,
-		public EventQueue < KeyboardEvent >,
-		public EventQueue < MouseMoveEvent >,
-		public EventQueue < MouseScrollEvent >,
-		public EventQueue < WindowResizedEvent > {
+		public CommandQueue<IMGUISystem>,
+		public EventQueue<KeyboardEvent>,
+		public EventQueue<MouseMoveEvent>,
+		public EventQueue<MouseScrollEvent>,
+		public EventQueue<WindowResizedEvent> {
 		typedef Command<IMGUISystem> GUICommand;
 	public:
 		IMGUISystem(GLFWwindow* window);
@@ -76,6 +76,10 @@ namespace tec {
 		static void SetClipboardText(void* user_data, const char* text);
 		static void RenderDrawLists(ImDrawData* draw_data);
 	private:
+		using EventQueue<WindowResizedEvent>::On;
+		using EventQueue<MouseMoveEvent>::On;
+		using EventQueue<MouseScrollEvent>::On;
+		using EventQueue<KeyboardEvent>::On;
 		void On(std::shared_ptr<WindowResizedEvent> data);
 		void On(std::shared_ptr<MouseMoveEvent > data);
 		void On(std::shared_ptr<MouseScrollEvent > data);

--- a/client/render-system.cpp
+++ b/client/render-system.cpp
@@ -66,12 +66,16 @@ namespace tec {
 			_log->error("[RenderSystem] Failed to create Light GBuffer.");
 		}
 
-		const char* tmp_buf{
+		const char* tmp_buf = {
 #include "resources/checker.c" // Carmack's trick . Contains a 128x128x1 bytes of monocrome texture data
-		 };
-		std::shared_ptr<PixelBuffer> default_pbuffer = std::make_shared<PixelBuffer>(64, 64, 8, ImageColorMode::COLOR_RGBA);
-		std::copy_n(tmp_buf, sizeof(tmp_buf), default_pbuffer->LockWrite());
-		default_pbuffer->UnlockWrite();
+		};
+
+		auto default_pbuffer = std::make_shared<PixelBuffer>(64, 64, 8, ImageColorMode::COLOR_RGBA);
+		{
+			std::lock_guard lg(default_pbuffer->GetWritelock());
+			std::copy_n(tmp_buf, sizeof(tmp_buf), default_pbuffer->GetPtr());
+		}
+
 		PixelBufferMap::Set("default", default_pbuffer);
 
 		std::shared_ptr<TextureObject> default_texture = std::make_shared<TextureObject>(default_pbuffer);

--- a/client/render-system.hpp
+++ b/client/render-system.hpp
@@ -55,6 +55,9 @@ namespace tec {
 		void FinalPass();
 		void RenderGbuffer();
 
+		using EventQueue<WindowResizedEvent>::On;
+		using EventQueue<EntityDestroyed>::On;
+		using EventQueue<EntityCreated>::On;
 		void On(std::shared_ptr<WindowResizedEvent> data);
 		void On(std::shared_ptr<EntityDestroyed> data);
 		void On(std::shared_ptr<EntityCreated> data);

--- a/client/resources/md5anim.cpp
+++ b/client/resources/md5anim.cpp
@@ -306,6 +306,6 @@ namespace tec {
 				glm::toMat4(finalJoint.orientation)) * this->joints[i].bind_pose_inverse;
 		}
 
-		return std::move(final_skeleton);
+		return final_skeleton;
 	}
 }

--- a/client/resources/pixel-buffer.cpp
+++ b/client/resources/pixel-buffer.cpp
@@ -179,18 +179,6 @@ namespace tec {
 		return nullptr;
 	}
 
-	uint8_t * PixelBuffer::LockWrite() {
-		if (blockptr) {
-			writelock.lock();
-			return blockptr.get();
-		}
-		return nullptr;
-	}
-
-	void PixelBuffer::UnlockWrite() {
-		writelock.unlock();
-	}
-
 #define STB_IMAGE_IMPLEMENTATION
 #include "resources/stb_image.h"
 

--- a/client/resources/pixel-buffer.hpp
+++ b/client/resources/pixel-buffer.hpp
@@ -94,16 +94,8 @@ namespace tec {
 		 */
 		const std::uint8_t* GetBlockBase() const;
 
-		/**
-		 * \brief Locks image for writing and gets pointer to base address of image data.
-		 * This function is intended for image processing or filling the pixel buffer.
-		 * \return uint8_t * base image address or nullptr if invalid or lock failed.
-		 */
-		std::uint8_t* LockWrite();
-		/**
-		 * \brief Unlocks image after writing, must be called if LockWrite was successful.
-		 */
-		void UnlockWrite();
+		std::mutex& GetWritelock() { return this->writelock; }
+		std::uint8_t* GetPtr() { return this->blockptr.get(); }
 
 		std::uint32_t Width() const { return imagewidth; }
 		std::uint32_t Height() const { return imageheight; }

--- a/client/resources/stb_vorbis.c
+++ b/client/resources/stb_vorbis.c
@@ -888,7 +888,7 @@ static int error(vorb *f, enum STBVorbisError e)
 #define array_size_required(count,size)  (count*(sizeof(void *)+(size)))
 
 #define temp_alloc(f,size)              (f->alloc.alloc_buffer ? setup_temp_malloc(f,size) : alloca(size))
-#define temp_free(f,p)                  0
+#define temp_free(f,p)                  (void)0
 #define temp_alloc_save(f)              ((f)->temp_offset)
 #define temp_alloc_restore(f,p)         ((f)->temp_offset = (p))
 

--- a/client/server-connection.cpp
+++ b/client/server-connection.cpp
@@ -101,7 +101,8 @@ namespace tec {
 			try {
 				asio::write(this->socket, asio::buffer(msg.GetDataPTR(), msg.length()));
 			}
-			catch (std::exception) {
+			catch (std::exception const& e) {
+				std::cerr << "ServerConnection::Send(ServerMessage&): asio::write:" << e.what() << std::endl;
 			}
 		}
 
@@ -149,8 +150,8 @@ namespace tec {
 						read_header();
 					}
 				}
-				catch (std::exception e) {
-					std::cout << e.what();
+				catch (std::exception const& e) {
+					std::cerr << "ServerConnection::StartRead(): Error reading header:" << e.what() << std::endl;
 				}
 				std::this_thread::sleep_for(std::chrono::milliseconds(1));
 			}

--- a/client/server-connection.cpp
+++ b/client/server-connection.cpp
@@ -10,8 +10,10 @@ using asio::ip::tcp;
 
 namespace tec {
 	namespace networking {
-		const char* SERVER_PORT_STR = "41228";
-		const char* LOCAL_HOST = "127.0.0.1";
+
+		const std::string_view SERVER_PORT = "41228";
+		const std::string_view LOCAL_HOST = "127.0.0.1";
+
 		std::shared_ptr<spdlog::logger> ServerConnection::_log;
 		std::mutex ServerConnection::recent_ping_mutex;
 
@@ -47,11 +49,11 @@ namespace tec {
 								   });
 		}
 
-		bool ServerConnection::Connect(std::string ip) {
+		bool ServerConnection::Connect(std::string_view ip) {
 			this->client_id = 0;
 			this->socket.close();
 			tcp::resolver resolver(this->io_service);
-			tcp::resolver::query query(ip, SERVER_PORT_STR);
+			tcp::resolver::query query(std::string(ip).data(), std::string(SERVER_PORT).data());
 			asio::error_code error = asio::error::host_not_found;
 			tcp::resolver::iterator endpoint_iterator = resolver.resolve(query), end;
 			try {

--- a/client/server-connection.hpp
+++ b/client/server-connection.hpp
@@ -24,8 +24,9 @@ namespace tec {
 	extern std::map<tid, std::function<void(const proto::Entity&, const proto::Component&, const state_id_t)>> update_functors;
 
 	namespace networking {
-		extern const char* SERVER_PORT_STR;
-		extern const char* LOCAL_HOST;
+		extern const std::string_view SERVER_PORT;
+		extern const std::string_view LOCAL_HOST;
+
 		typedef std::chrono::milliseconds::rep ping_time_t;
 		// std::chrono::milliseconds::rep is required to be signed and at least
 		// 45 bits, so it should be std::int64_t.
@@ -36,7 +37,7 @@ namespace tec {
 		public:
 			ServerConnection();
 
-			bool Connect(std::string ip = LOCAL_HOST); // Connects to a server.
+			bool Connect(std::string_view ip = LOCAL_HOST); // Connects to a server.
 
 			void Disconnect(); // Closes the socket connection and stops the read and sync loops.
 

--- a/client/sound-system.hpp
+++ b/client/sound-system.hpp
@@ -71,8 +71,9 @@ namespace tec {
 		std::string audio_name;
 	};
 
-	class SoundSystem : public CommandQueue < SoundSystem >,
-		public EventQueue<EntityCreated>, public EventQueue<EntityDestroyed> {
+	class SoundSystem : public CommandQueue<SoundSystem>,
+		public EventQueue<EntityCreated>,
+		public EventQueue<EntityDestroyed> {
 	public:
 		SoundSystem();
 
@@ -85,6 +86,9 @@ namespace tec {
 		void Stop() {
 			this->running = false;
 		}
+
+		using EventQueue<EntityCreated>::On;
+		using EventQueue<EntityDestroyed>::On;
 		void On(std::shared_ptr<EntityCreated> data);
 		void On(std::shared_ptr<EntityDestroyed> data);
 	private:

--- a/client/test-data.cpp
+++ b/client/test-data.cpp
@@ -174,7 +174,7 @@ namespace tec {
 		input.seekg(0, std::ios::beg);
 		std::copy((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>(), std::back_inserter(in));
 		input.close();
-		return std::move(in);
+		return in;
 	}
 
 	void ProtoLoadEntity(const FilePath& fname) {

--- a/client/voxel-volume.cpp
+++ b/client/voxel-volume.cpp
@@ -149,10 +149,10 @@ namespace tec {
 					std::int16_t z = static_cast<std::int16_t>(index & 0xFFFF);
 					std::size_t vertex_offset = _mesh->verts.size();
 					for (std::size_t i = 0; i < 24; ++i) {
-						_mesh->verts.push_back(std::move(VertexData(IdentityVerts[i].position[0] + x,
+						_mesh->verts.push_back(VertexData(IdentityVerts[i].position[0] + x,
 							IdentityVerts[i].position[1] + y, IdentityVerts[i].position[2] + z,
 							IdentityVerts[i].color[0], IdentityVerts[i].color[1], IdentityVerts[i].color[2],
-							IdentityVerts[i].uv[0], IdentityVerts[i].uv[1])));
+							IdentityVerts[i].uv[0], IdentityVerts[i].uv[1]));
 					}
 					this->vertex_index[index] = vertex_offset;
 					for (std::size_t i = 0; i < 6; ++i) {
@@ -219,14 +219,12 @@ namespace tec {
 			mesh = MeshMap::Get(name);
 			mesh.lock()->SetName(name);
 		}
-		auto voxvol = std::make_shared<VoxelVolume>(entity_id, mesh);
-		VoxelVoumeMap::Set(entity_id, voxvol);
-		return voxvol;
+		return Create(entity_id, mesh);
 	}
 
 	std::weak_ptr<VoxelVolume> VoxelVolume::Create(eid entity_id, std::weak_ptr<MeshFile> mesh) {
 		auto voxvol = std::make_shared<VoxelVolume>(entity_id, mesh);
-		VoxelVoumeMap::Set(entity_id, voxvol);
+		VoxelVolumeMap::Set(entity_id, voxvol);
 		return voxvol;
 	}
 

--- a/client/voxel-volume.cpp
+++ b/client/voxel-volume.cpp
@@ -244,7 +244,7 @@ namespace tec {
 			}
 		}
 		else if (data->button == MouseBtnEvent::RIGHT) {
-			if (entity_id == this->entity_id) {
+			if (data->entity_id == this->entity_id) {
 				const Position* pos = Entity(entity_id).Get<Position>();
 				const Orientation* orientation = Entity(entity_id).Get<Orientation>();
 				glm::mat4 model_view = glm::inverse(glm::translate(glm::mat4(1.0), pos->value) * glm::mat4_cast(orientation->value));

--- a/client/voxel-volume.hpp
+++ b/client/voxel-volume.hpp
@@ -27,7 +27,7 @@ namespace tec {
 	};
 
 	class VoxelVolume;
-	typedef Multiton<eid, std::shared_ptr<VoxelVolume>> VoxelVoumeMap;
+	typedef Multiton<eid, std::shared_ptr<VoxelVolume>> VoxelVolumeMap;
 
 	typedef Command<VoxelVolume> VoxelCommand;
 
@@ -63,6 +63,7 @@ namespace tec {
 		// Creates a VoxelVolume for entity_id and uses PolygonMeshData and into sub-mesh.
 		static std::weak_ptr<VoxelVolume> Create(const eid entity_id, std::weak_ptr<MeshFile> mesh = std::weak_ptr<MeshFile>());
 		
+		using EventQueue<MouseClickEvent>::On;
 		void On(std::shared_ptr<MouseClickEvent> data);
 	private:
 		std::unordered_map<std::int64_t, std::shared_ptr<Voxel>> voxels;

--- a/common/components/collision-body.hpp
+++ b/common/components/collision-body.hpp
@@ -12,7 +12,9 @@
 
 namespace tec {
 	ATTRIBUTE_ALIGNED16(struct) CollisionBody {
+
 		BT_DECLARE_ALIGNED_ALLOCATOR();
+
 		struct MotionState : public btMotionState {
 			MotionState() {
 				this->transform.setIdentity();
@@ -22,12 +24,8 @@ namespace tec {
 
 			MotionState& operator=(MotionState&& other) noexcept {
 				transform_updated = other.transform_updated;
-				transform = std::move(transform);
 				return *this;
 			}
-			btTransform transform;
-
-			bool transform_updated{ true };
 
 			void getWorldTransform(btTransform& worldTrans) const {
 				worldTrans = this->transform;
@@ -37,7 +35,11 @@ namespace tec {
 				this->transform_updated = true;
 				this->transform = worldTrans;
 			}
+
+			btTransform transform;
+			bool transform_updated = true;
 		};
+
 		CollisionBody() = default;
 		CollisionBody(CollisionBody && other) noexcept;
 
@@ -46,12 +48,11 @@ namespace tec {
 		void Out(proto::Component * target);
 		void In(const proto::Component & source);
 
-		btScalar mass{ 0.f }; // For static objects mass must be 0.
-		bool disable_deactivation{ false }; // Whether to disable automatic deactivation.
-		bool disable_rotation{ false }; // prevent rotation from physics simulation.
-
+		btScalar mass = 0.0f;              // For static objects mass must be 0.
+		bool disable_deactivation = false; // Whether to disable automatic deactivation.
+		bool disable_rotation = false;     // prevent rotation from physics simulation.
 		std::shared_ptr<btCollisionShape> shape;
-		eid entity_id{ 0 }; // Stored to use when doing lookups during collision
+		eid entity_id = 0; // Stored to use when doing lookups during collision
 		MotionState motion_state;
 	};
 }

--- a/common/components/transforms.hpp
+++ b/common/components/transforms.hpp
@@ -8,9 +8,9 @@
 #include <components.pb.h>
 
 namespace tec {
-	static glm::vec3 FORWARD_VECTOR(0.0f, 0.0f, -1.0f);
-	static glm::vec3 UP_VECTOR(0.0f, 1.0f, 0.0f);
-	static glm::vec3 RIGHT_VECTOR(1.0f, 0.0f, 0.0f);
+	static glm::vec3 FORWARD_VECTOR = {0.0f, 0.0f, -1.0f};
+	static glm::vec3 UP_VECTOR = {0.0f, 1.0f, 0.0f};
+	static glm::vec3 RIGHT_VECTOR = {1.0f, 0.0f, 0.0f};
 
 	struct Position {
 		Position(glm::vec3 pos) : value(pos) {}
@@ -21,8 +21,8 @@ namespace tec {
 		// Translates by amount in direction orientation.
 		void Translate(const glm::vec3 amount, const glm::quat orientation);
 
-		glm::vec3 value{ 0,0,0 };
-		glm::vec3 center_offset{ 0,0,0 };
+		glm::vec3 value = {0.0f, 0.0f, 0.0f};
+		glm::vec3 center_offset = {0.0f, 0.0f, 0.0f};
 
 		void Out(proto::Component* target);
 		void In(const proto::Component& source);

--- a/common/controllers/fps-controller.cpp
+++ b/common/controllers/fps-controller.cpp
@@ -6,6 +6,9 @@
 #include <iostream>
 
 #include <glm/gtx/quaternion.hpp>
+
+#define GLFW_INCLUDE_GL3
+#define GL_SILENCE_DEPRECATION
 #include <GLFW/glfw3.h> // TODO: included for key constants
 
 #include "components/transforms.hpp"
@@ -113,7 +116,7 @@ namespace tec {
 			_orientation->set_z(this->orientation->value.z);
 			_orientation->set_w(this->orientation->value.w);
 		}
-		return std::move(proto_client_commands);
+		return proto_client_commands;
 	}
 
 	void FPSController::ApplyClientCommands(proto::ClientCommands proto_client_commands) {

--- a/common/controllers/fps-controller.hpp
+++ b/common/controllers/fps-controller.hpp
@@ -38,9 +38,9 @@ namespace tec {
 		void Handle(const MouseBtnEvent& data, const GameState& state);
 		void Handle(const MouseMoveEvent& data, const GameState& state);
 
-		void Update(double delta, GameState& state, EventList& commands);
+		void Update(double delta, GameState& state, EventList& commands) override;
 
-		proto::ClientCommands GetClientCommands();
+		proto::ClientCommands GetClientCommands() override;
 
 		bool forward{ false };
 		bool backward{ false };

--- a/common/game-state-queue.cpp
+++ b/common/game-state-queue.cpp
@@ -8,7 +8,7 @@ namespace tec {
 	static const double INTERPOLATION_RATE = 10.0 / 60.0;
 
 	void GameStateQueue::Interpolate(const double delta_time) {
-		std::lock_guard<std::mutex> lock(this->server_state_mutex);
+		std::lock_guard<std::mutex> lg(this->server_state_mutex);
 		if (this->server_states.size() > 5) {
 			std::cout << "getting flooded by state updates" << std::endl;
 		}
@@ -95,7 +95,7 @@ namespace tec {
 			this->server_states_array[server_state_array_index % SERVER_STATES_ARRAY_SIZE] = new_state;
 			server_state_array_index++;
 			this->last_server_state_id = new_state.state_id;
-			std::lock_guard<std::mutex> lock(this->server_state_mutex);
+			std::lock_guard<std::mutex> lg(this->server_state_mutex);
 			CheckPredictionResult(new_state);
 			this->server_states.emplace(std::move(new_state));
 		}

--- a/common/game-state-queue.hpp
+++ b/common/game-state-queue.hpp
@@ -30,9 +30,12 @@ namespace tec {
 			this->command_id = _command_id;
 		}
 
-		void On(std::shared_ptr<EntityCreated> data);
-		void On(std::shared_ptr<EntityDestroyed> data);
-		void On(std::shared_ptr<NewGameStateEvent> data);
+		using EventQueue<EntityCreated>::On;
+		using EventQueue<EntityDestroyed>::On;
+		using EventQueue<NewGameStateEvent>::On;
+		virtual void On(std::shared_ptr<EntityCreated> data);
+		virtual void On(std::shared_ptr<EntityDestroyed> data);
+		virtual void On(std::shared_ptr<NewGameStateEvent> data);
 
 		GameState& GetInterpolatedState() {
 			return this->interpolated_state;

--- a/common/lua-system.cpp
+++ b/common/lua-system.cpp
@@ -12,7 +12,7 @@ namespace tec {
 		auto _log = spdlog::get("console_log");
 		ProcessCommandQueue();
 		
-		for (auto itr = ScriptsMap::Begin(); itr != ScriptsMap::End(); itr++) {
+		for (auto itr = this->scripts_map.Begin(); itr != this->scripts_map.End(); itr++) {
 			auto entity_id = itr->first;
 			if (Entity(entity_id).Has<LuaScript>()) {
 				if (const LuaScript* lscript = Entity(entity_id).Get<LuaScript>()) {

--- a/common/lua-system.hpp
+++ b/common/lua-system.hpp
@@ -20,13 +20,13 @@ namespace tec {
 	class LuaSystem;
 	typedef Command<LuaSystem> LuaCommand;
 	
-	class LuaSystem :
-		public CommandQueue<LuaSystem> {
+	class LuaSystem : public CommandQueue<LuaSystem> {
 	public:		
 		void Update(const double delta);
 		
 	private:
-		typedef Multiton<eid, std::shared_ptr<LuaScript>> ScriptsMap;
+		using ScriptsMap_t = Multiton<eid, std::shared_ptr<LuaScript>>;
+        ScriptsMap_t scripts_map;
 	};
 	
 }

--- a/common/physics-system.cpp
+++ b/common/physics-system.cpp
@@ -130,7 +130,7 @@ namespace tec {
 				itr->second->motion_state.transform_updated = false;
 			}
 		}
-		return std::move(updated_entities);
+		return updated_entities;
 	}
 
 	glm::vec3 GetRayDirection(float mouse_x, float mouse_y, float screen_width, float screen_height, glm::mat4 view, glm::mat4 projection) {
@@ -379,7 +379,7 @@ namespace tec {
 			if (Entity(entity_id).Has<Position>()) {
 				position.center_offset = Entity(entity_id).Get<Position>()->center_offset;
 			}
-			return std::move(position);
+			return position;
 		}
 		return glm::vec3();
 	}
@@ -393,7 +393,7 @@ namespace tec {
 			if (Entity(entity_id).Has<Orientation>()) {
 				orientation.rotation_offset = Entity(entity_id).Get<Orientation>()->rotation_offset;
 			}
-			return std::move(orientation);
+			return orientation;
 		}
 		return glm::quat();
 	}

--- a/common/physics-system.hpp
+++ b/common/physics-system.hpp
@@ -43,6 +43,10 @@ namespace tec {
 		}
 
 		void DebugDraw();
+
+		using EventQueue<MouseBtnEvent>::On;
+		using EventQueue<EntityCreated>::On;
+		using EventQueue<EntityDestroyed>::On;
 		void On(std::shared_ptr<MouseBtnEvent> data);
 		void On(std::shared_ptr<EntityCreated> data);
 		void On(std::shared_ptr<EntityDestroyed> data);

--- a/common/simulation.cpp
+++ b/common/simulation.cpp
@@ -41,7 +41,7 @@ namespace tec {
 
 		GameState client_state = interpolated_state;
 		std::future<std::set<eid>> phys_future = std::async(std::launch::async, [=, &interpolated_state]() -> std::set < eid > {
-			return std::move(phys_sys.Update(delta_time, interpolated_state));
+			return phys_sys.Update(delta_time, interpolated_state);
 		});
 		std::set<eid> phys_results = phys_future.get();
 

--- a/common/simulation.hpp
+++ b/common/simulation.hpp
@@ -42,6 +42,13 @@ namespace tec {
 		void AddController(Controller* controller);
 		void RemoveController(Controller* controller);
 
+		using EventQueue<KeyboardEvent>::On;
+		using EventQueue<MouseBtnEvent>::On;
+		using EventQueue<MouseMoveEvent>::On;
+		using EventQueue<MouseClickEvent>::On;
+		using EventQueue<ClientCommandsEvent>::On;
+		using EventQueue<ControllerAddedEvent>::On;
+		using EventQueue<ControllerRemovedEvent>::On;
 		void On(std::shared_ptr<KeyboardEvent> data);
 		void On(std::shared_ptr<MouseBtnEvent> data);
 		void On(std::shared_ptr<MouseMoveEvent> data);

--- a/common/vcomputer-system.hpp
+++ b/common/vcomputer-system.hpp
@@ -34,7 +34,7 @@ namespace tec {
 		~Computer() {
 			if (this->rom) {
 				this->vc.Off();
-				delete this->rom;
+				delete[] this->rom;
 			}
 		}
 		std::uint8_t *rom;
@@ -51,6 +51,7 @@ namespace tec {
 	class TextureObject;
 	struct ComputerScreen : DeviceBase {
 		ComputerScreen();
+		virtual ~ComputerScreen() = default;
 		std::shared_ptr<TextureObject> texture;
 
 		void In(const proto::Computer::Device& source);
@@ -60,6 +61,7 @@ namespace tec {
 
 	struct ComputerKeyboard : DeviceBase {
 		ComputerKeyboard();
+		virtual ~ComputerKeyboard() = default;
 
 		bool has_focus{ false };
 
@@ -71,8 +73,10 @@ namespace tec {
 	struct KeyboardEvent;
 	struct MouseBtnEvent;
 
-	class VComputerSystem final : public CommandQueue < VComputerSystem >,
-		public EventQueue < KeyboardEvent >, public EventQueue < MouseBtnEvent > {
+	class VComputerSystem final :
+        public CommandQueue<VComputerSystem>,
+		public EventQueue<KeyboardEvent>,
+        public EventQueue<MouseBtnEvent> {
 	public:
 		VComputerSystem();
 
@@ -122,6 +126,8 @@ namespace tec {
 		 */
 		void Update(double delta);
 
+		using EventQueue<KeyboardEvent>::On;
+		using EventQueue<MouseBtnEvent>::On;
 		void On(std::shared_ptr<KeyboardEvent> data);
 		void On(std::shared_ptr<MouseBtnEvent> data);
 	private:

--- a/server/client-connection.cpp
+++ b/server/client-connection.cpp
@@ -37,7 +37,7 @@ namespace tec {
 		void ClientConnection::QueueWrite(const ServerMessage& msg) {
 			bool write_in_progress;
 			{
-				std::lock_guard<std::mutex> lock(write_msg_mutex);
+				std::lock_guard<std::mutex> lg(write_msg_mutex);
 				write_in_progress = !write_msgs_.empty();
 				write_msgs_.push_back(msg);
 			}
@@ -179,7 +179,7 @@ namespace tec {
 
 		void ClientConnection::do_write() {
 			auto self(shared_from_this());
-			std::lock_guard<std::mutex> lock(write_msg_mutex);
+			std::lock_guard<std::mutex> lg(write_msg_mutex);
 			asio::async_write(
 				socket,
 				asio::buffer(write_msgs_.front().GetDataPTR(),
@@ -188,7 +188,7 @@ namespace tec {
 					if (!error) {
 						bool more_to_write = false;
 						{
-							std::lock_guard<std::mutex> lock(write_msg_mutex);
+							std::lock_guard<std::mutex> lg(write_msg_mutex);
 							write_msgs_.pop_front();
 							more_to_write = !write_msgs_.empty();
 						}
@@ -238,7 +238,7 @@ namespace tec {
 			update_message.SetBodyLength(gsu_msg.ByteSize());
 			gsu_msg.SerializeToArray(update_message.GetBodyPTR(), static_cast<int>(update_message.GetBodyLength()));
 			update_message.encode_header();
-			return std::move(update_message);
+			return update_message;
 		}
 	}
 }

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -52,14 +52,14 @@ int main() {
 	std::chrono::duration<double> elapsed_seconds;
 	bool closing = false;
 
-    // Accumulated deltas since the last update was sent.
+	// Accumulated deltas since the last update was sent.
 	double delta_accumulator = 0.0;
 
 	tec::GameStateQueue game_state_queue;
 	tec::Simulation simulation;
 
 	try {
-		tcp::endpoint endpoint(asio::ip::tcp::v4(), tec::networking::SERVER_PORT);
+		tcp::endpoint endpoint(asio::ip::tcp::v4(), tec::networking::PORT);
 		tec::networking::Server server(endpoint);
 		std::cout << "Server ready" << std::endl;
 

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -102,7 +102,6 @@ int main() {
 							}
 						}
 
-						server.UnlockClientList();
 						delta_accumulator -= tec::UPDATE_RATE;
 						game_state_queue.SetBaseState(std::move(full_state));
 					}

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -15,7 +15,7 @@ using asio::ip::tcp;
 
 namespace tec {
 	namespace networking {
-		unsigned short SERVER_PORT = 0xa10c;
+		unsigned short PORT = 0xa10c;
 		std::mutex Server::recent_msgs_mutex;
 
 		Server::Server(tcp::endpoint& endpoint) : acceptor(io_service, endpoint), socket(io_service) {

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -32,18 +32,19 @@ namespace tec {
 		// TODO: Implement a method to deliver a message to all clients except the source.
 		void Server::Deliver(const ServerMessage& msg, bool save_to_recent) {
 			if (save_to_recent) {
-				std::lock_guard<std::mutex> lock(recent_msgs_mutex);
+				std::lock_guard<std::mutex> lg(recent_msgs_mutex);
 				this->recent_msgs.push_back(msg);
 				while (this->recent_msgs.size() > max_recent_msgs) {
 					this->recent_msgs.pop_front();
 				}
 			}
 
-			LockClientList();
-			for (auto client : this->clients) {
-				client->QueueWrite(msg);
+			{
+				std::lock_guard<std::mutex> lg(client_list_mutex);
+				for (auto client : this->clients) {
+					client->QueueWrite(msg);
+				}
 			}
-			UnlockClientList();
 		}
 
 		void Server::Deliver(std::shared_ptr<ClientConnection> client, const ServerMessage& msg) {
@@ -54,9 +55,10 @@ namespace tec {
 			eid leaving_client_id = client->GetID();
 			client->DoLeave(); // Send out entity destroyed events and client leave messages.
 
-			LockClientList();
-			this->clients.erase(client);
-			UnlockClientList();
+            {
+                std::lock_guard lg(this->client_list_mutex);
+                this->clients.erase(client);
+            }
 
 			// Notify other clients that a client left.
 			for (auto _client : this->clients) {
@@ -69,9 +71,10 @@ namespace tec {
 		}
 
 		void Server::Stop() {
-			LockClientList();
-			this->clients.clear();
-			UnlockClientList();
+			{
+				std::lock_guard<std::mutex> lg(client_list_mutex);
+				this->clients.clear();
+			}
 			this->io_service.stop();
 		}
 
@@ -138,11 +141,12 @@ namespace tec {
 							client->QueueWrite(other_client_entity_msg);
 						}
 
-						LockClientList();
-						clients.insert(client);
-						UnlockClientList();
 						{
-							std::lock_guard<std::mutex> lock(recent_msgs_mutex);
+							std::lock_guard lg(this->client_list_mutex);
+							clients.insert(client);
+						}
+						{
+							std::lock_guard<std::mutex> lg(recent_msgs_mutex);
 							for (auto msg : this->recent_msgs) {
 								client->QueueWrite(msg);
 							}

--- a/server/server.hpp
+++ b/server/server.hpp
@@ -40,20 +40,13 @@ namespace tec {
 
 			void Stop();
 
-			void LockClientList() {
-				this->client_list_mutex.lock();
-			}
-
-			void UnlockClientList() {
-				
-				this->client_list_mutex.unlock();
-			}
-
 			// Get a list of all connected clients.
 			const std::set<std::shared_ptr<ClientConnection>>& GetClients() {
 				return this->clients;
 			}
 
+			using EventQueue<EntityCreated>::On;
+			using EventQueue<EntityDestroyed>::On;
 			void On(std::shared_ptr<EntityCreated> data);
 			void On(std::shared_ptr<EntityDestroyed> data);
 		private:
@@ -76,6 +69,7 @@ namespace tec {
 			enum { max_recent_msgs = 100 };
 			std::deque<ServerMessage> recent_msgs;
 			static std::mutex recent_msgs_mutex;
+		public:
 			std::mutex client_list_mutex;
 		};
 	}

--- a/server/server.hpp
+++ b/server/server.hpp
@@ -19,7 +19,7 @@ using asio::ip::tcp;
 
 namespace tec {
 	namespace networking {
-		extern unsigned short SERVER_PORT;
+		extern unsigned short PORT;
 		class ClientConnection;
 
 		class Server : public EventQueue<EntityCreated>, public EventQueue<EntityDestroyed> {

--- a/tests/client-server-connection.cpp
+++ b/tests/client-server-connection.cpp
@@ -23,7 +23,7 @@ TEST(ClientServerConnection_test, Constructor) {
 	auto log = std::make_shared<spdlog::logger>("console_log", begin(sinks), end(sinks));
 	spdlog::register_logger(log);
 
-	tcp::endpoint endpoint(asio::ip::tcp::v4(), tec::networking::SERVER_PORT);
+	tcp::endpoint endpoint(asio::ip::tcp::v4(), tec::networking::PORT);
 	tec::networking::Server server(endpoint);
 	std::thread start_thread([&server] () {server.Start(); });
 

--- a/tests/client-server-connection.cpp
+++ b/tests/client-server-connection.cpp
@@ -2,7 +2,7 @@
 // Licensed under the terms of the LGPLv3. See licenses/lgpl-3.0.txt
 
 /**
- * Unit tests of VComputer
+ * Unit tests
  */
 
 #include <gtest/gtest.h>


### PR DESCRIPTION
Now builds with almost no warnings on my mac laptop: just one warning about `tec::GameStateQueue::predicted_states_array_index` being an unused private field and one about unhandled enumeration values in a switch in `tec::networking::ClientConnection::read_body`.