### PR TITLE
Fixed FilePath reference resolution of path

### DIFF
--- a/common/filesystem.hpp
+++ b/common/filesystem.hpp
@@ -453,6 +453,5 @@ private:
 		is >> tmp;
 		path = FilePath(tmp);
 	}
-
 }
 

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -26,7 +26,7 @@ namespace tec {
 	std::string LoadJSON(const FilePath& fname) {
 		std::fstream input(fname.GetNativePath(), std::ios::in | std::ios::binary);
 		if (!input.good())
-			throw std::runtime_error("can't open ." + *fname.GetNativePath().c_str());
+			throw std::runtime_error("can't open ." + fname.toString());
 
 		std::string in;
 		input.seekg(0, std::ios::end);


### PR DESCRIPTION
Changed resolution of path for the server to use the simple path variable, but may need to change if this breaks with the platform specific code (re: Windows' use of wstring). 