### PR TITLE
Remove inout functors

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -25,6 +25,7 @@ endif ()
 set(trillek-client_SOURCES # don't include main.cpp to keep it out of tests
 	${trillek-client_SOURCE_DIR}/game.cpp
 	${trillek-client_SOURCE_DIR}/imgui-system.cpp
+	${trillek-client_SOURCE_DIR}/file-factories.cpp
 	${trillek-client_SOURCE_DIR}/os.cpp
 	${trillek-client_SOURCE_DIR}/render-system.cpp
 	${trillek-client_SOURCE_DIR}/server-connection.cpp

--- a/client/file-factories.cpp
+++ b/client/file-factories.cpp
@@ -1,0 +1,38 @@
+// Copyright (c) 2013-2016 Trillek contributors. See AUTHORS.txt for details
+// Licensed under the terms of the LGPLv3. See licenses/lgpl-3.0.txt
+
+#include <functional>
+#include <unordered_map>
+
+#include "resources/md5mesh.hpp"
+#include "resources/obj.hpp"
+#include "resources/md5anim.hpp"
+#include "resources/vorbis-stream.hpp"
+#include "resources/script-file.hpp"
+
+#include "types.hpp"
+#include "filesystem.hpp"
+
+namespace tec {
+	std::unordered_map<std::string, std::function<void(std::string)>> file_factories;
+	template <typename T>
+	void AddFileFactory() {
+		file_factories[GetTypeEXT<T>()] = [] (std::string fname) {
+			FilePath path(fname);
+			if (path.isAbsolutePath()) {
+				T::Create(fname);
+			}
+			else {
+				T::Create(FilePath::GetAssetPath(fname));
+			}
+		};
+	}
+
+	void InitializeFileFactories() {
+		AddFileFactory<MD5Mesh>();
+		AddFileFactory<MD5Anim>();
+		AddFileFactory<OBJ>();
+		AddFileFactory<VorbisStream>();
+		AddFileFactory<ScriptFile>();
+	}
+}

--- a/client/graphics/animation.cpp
+++ b/client/graphics/animation.cpp
@@ -65,7 +65,7 @@ namespace tec {
 		comp->set_animation_name(this->animation_name);
 	}
 
-	extern std::map<std::string, std::function<void(std::string)>> file_factories;
+	extern std::unordered_map<std::string, std::function<void(std::string)>> file_factories;
 	void Animation::In(const proto::Component& source) {
 		const proto::Animation& comp = source.animation();
 		if (comp.has_animation_name()) {

--- a/client/graphics/renderable.cpp
+++ b/client/graphics/renderable.cpp
@@ -29,7 +29,7 @@ namespace tec {
 		this->local_orientation.Out(comp->mutable_orientation());
 	}
 
-	extern std::map<std::string, std::function<void(std::string)>> file_factories;
+	extern std::unordered_map<std::string, std::function<void(std::string)>> file_factories;
 
 	void Renderable::In(const proto::Component& source) {
 		const proto::Renderable& comp = source.renderable();

--- a/client/imgui-system.cpp
+++ b/client/imgui-system.cpp
@@ -370,7 +370,7 @@ namespace tec {
 		this->mouse_wheel.x = static_cast<float>(data->x_offset);
 		this->mouse_wheel.y = static_cast<float>(data->y_offset);
 	}
-	
+
 
 	void IMGUISystem::On(std::shared_ptr<MouseBtnEvent> data) {
 		this->mouse_pressed[data->button] = data->action == MouseBtnEvent::DOWN;

--- a/client/imgui-system.cpp
+++ b/client/imgui-system.cpp
@@ -370,7 +370,11 @@ namespace tec {
 		this->mouse_wheel.x = static_cast<float>(data->x_offset);
 		this->mouse_wheel.y = static_cast<float>(data->y_offset);
 	}
+	
 
+	void IMGUISystem::On(std::shared_ptr<MouseBtnEvent> data) {
+		this->mouse_pressed[data->button] = data->action == MouseBtnEvent::DOWN;
+	}
 
 	void IMGUISystem::On(std::shared_ptr<MouseBtnEvent> data) {
 		this->mouse_pressed[data->button] = data->action == MouseBtnEvent::DOWN;

--- a/client/imgui-system.cpp
+++ b/client/imgui-system.cpp
@@ -371,11 +371,6 @@ namespace tec {
 		this->mouse_wheel.y = static_cast<float>(data->y_offset);
 	}
 
-
-	void IMGUISystem::On(std::shared_ptr<MouseBtnEvent> data) {
-		this->mouse_pressed[data->button] = data->action == MouseBtnEvent::DOWN;
-	}
-
 	void IMGUISystem::On(std::shared_ptr<MouseBtnEvent> data) {
 		this->mouse_pressed[data->button] = data->action == MouseBtnEvent::DOWN;
 	}

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -20,7 +20,6 @@
 #include <spdlog/sinks/stdout_sinks.h>
 
 namespace tec {
-	extern void InitializeComponents();
 	extern void InitializeFileFactories();
 	extern void BuildTestEntities();
 	extern void ProtoLoad(std::string filename);
@@ -111,7 +110,6 @@ int main(int argc, char* argv[]) {
 			gui.ShowWindow("ping_times");
 		});
 
-	tec::InitializeComponents();
 	tec::InitializeFileFactories();
 	tec::BuildTestEntities();
 	tec::ProtoLoad("json/test.json");

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -21,7 +21,7 @@
 
 namespace tec {
 	extern void InitializeFileFactories();
-	extern void BuildTestEntities();
+	extern void BuildTestVoxelVolume();
 	extern void ProtoLoad(std::string filename);
 }
 
@@ -111,7 +111,7 @@ int main(int argc, char* argv[]) {
 		});
 
 	tec::InitializeFileFactories();
-	tec::BuildTestEntities();
+	tec::BuildTestVoxelVolume();
 	tec::ProtoLoad("json/test.json");
 
 	os.DetachContext();

--- a/client/render-system.cpp
+++ b/client/render-system.cpp
@@ -29,6 +29,9 @@
 namespace tec {
 	using PointLightMap = Multiton<eid, PointLight*>;
 	using DirectionalLightMap = Multiton<eid, DirectionalLight*>;
+	using RenderableMap = Multiton<eid, Renderable*>;
+	using AnimationMap = Multiton<eid, Animation*>;
+	using ScaleMap = Multiton<eid, Scale*>;
 
 	RenderSystem::RenderSystem() {
 		_log = spdlog::get("console_log");
@@ -238,8 +241,8 @@ namespace tec {
 			if (Multiton<eid, Orientation*>::Has(entity_id)) {
 				orientation = Multiton<eid, Orientation*>::Get(entity_id)->value;
 			}
-			if (Multiton<eid, Scale*>::Has(entity_id)) {
-				scale = Multiton<eid, Scale*>::Get(entity_id)->value;
+			if (ScaleMap::Has(entity_id)) {
+				scale = ScaleMap::Get(entity_id)->value;
 			}
 
 			glm::mat4 transform_matrix = glm::scale(glm::translate(glm::mat4(1.0), position) *
@@ -392,8 +395,6 @@ namespace tec {
 		auto deferred_shadow_shader = Shader::CreateFromFile("deferred_shadow", deferred_shadow_shader_files);
 	}
 
-	using RenderableMap = Multiton<eid, Renderable*>;
-	using AnimationMap = Multiton<eid, Animation*>;
 	void RenderSystem::On(std::shared_ptr<WindowResizedEvent> data) {
 		SetViewportSize(data->new_width, data->new_height);
 	}
@@ -437,10 +438,17 @@ namespace tec {
 					AnimationMap::Set(entity_id, animation);
 				}
 				break;
+				case proto::Component::kScale:
+				{
+					Scale* scale = new Scale();
+					scale->In(comp);
+
+					ScaleMap::Set(entity_id, scale);
+				}
+				break;
 				case proto::Component::kPosition:
 				case proto::Component::kOrientation:
 				case proto::Component::kView:
-				case proto::Component::kScale:
 				case proto::Component::kCollisionBody:
 				case proto::Component::kVelocity:
 				case proto::Component::kAudioSource:
@@ -479,8 +487,8 @@ namespace tec {
 			}
 			glm::vec3 scale(1.0);
 			Entity e(entity_id);
-			if (Multiton<eid, Scale*>::Has(entity_id)) {
-				scale = Multiton<eid, Scale*>::Get(entity_id)->value;
+			if (ScaleMap::Has(entity_id)) {
+				scale = ScaleMap::Get(entity_id)->value;
 			}
 
 			this->model_matricies[entity_id] = glm::scale(glm::translate(glm::mat4(1.0), position) *

--- a/client/server-connection.hpp
+++ b/client/server-connection.hpp
@@ -20,9 +20,6 @@
 using asio::ip::tcp;
 
 namespace tec {
-	extern std::map<tid, std::function<void(const proto::Entity&, const proto::Component&)>> in_functors;
-	extern std::map<tid, std::function<void(const proto::Entity&, const proto::Component&, const state_id_t)>> update_functors;
-
 	namespace networking {
 		extern const std::string_view SERVER_PORT;
 		extern const std::string_view LOCAL_HOST;

--- a/client/sound-system.hpp
+++ b/client/sound-system.hpp
@@ -26,7 +26,7 @@ namespace tec {
 
 	enum class AUDIOSOURCE_STATE { PLAYING, PAUSED, STOPPED };
 
-	extern std::map<std::string, std::function<void(std::string)>> file_factories;
+	extern std::unordered_map<std::string, std::function<void(std::string)>> file_factories;
 	struct AudioSource {
 		AudioSource(std::shared_ptr<VorbisStream> stream, bool auto_play) :
 			vorbis_stream(stream), source_state(auto_play ? AUDIOSOURCE_STATE::PLAYING : AUDIOSOURCE_STATE::PAUSED) {}

--- a/client/test-data.cpp
+++ b/client/test-data.cpp
@@ -2,31 +2,20 @@
 // Licensed under the terms of the LGPLv3. See licenses/lgpl-3.0.txt
 
 #include <iostream>
-#include <map>
-#include <set>
+#include <fstream>
 #include <memory>
 
 #include <spdlog/spdlog.h>
 #include <google/protobuf/util/json_util.h>
 #include <components.pb.h>
 
-// Used in InitializeComponents
-#include "components/transforms.hpp" // TODO: Figured out who should handle loading Scale component
 #include "voxel-volume.hpp"
 
-// Used in InitializeFileFactories 
-#include "resources/md5mesh.hpp"
-#include "resources/obj.hpp"
-#include "resources/md5anim.hpp"
-#include "resources/vorbis-stream.hpp"
-#include "resources/script-file.hpp"
-
-#include "entity.hpp"
-#include "types.hpp"
 #include "events.hpp"
+#include "filesystem.hpp"
 
 namespace tec {
-	void BuildTestEntities() {
+	void BuildTestVoxelVolume() {
 		auto voxvol = VoxelVolume::Create(1000, "bob");
 		auto voxvol_shared = voxvol.lock();
 
@@ -40,30 +29,6 @@ namespace tec {
 		});
 		VoxelVolume::QueueCommand(std::move(add_voxel));
 		voxvol_shared->Update(0.0);
-	}
-
-	// Move below to more appropriate classes or files
-
-	std::map<std::string, std::function<void(std::string)>> file_factories;
-	template <typename T>
-	void AddFileFactory() {
-		file_factories[GetTypeEXT<T>()] = [](std::string fname) {
-			FilePath path(fname);
-			if (path.isAbsolutePath()) {
-				T::Create(fname);
-			}
-			else {
-				T::Create(FilePath::GetAssetPath(fname));
-			}
-		};
-	}
-
-	void InitializeFileFactories() {
-		AddFileFactory<MD5Mesh>();
-		AddFileFactory<MD5Anim>();
-		AddFileFactory<OBJ>();
-		AddFileFactory<VorbisStream>();
-		AddFileFactory<ScriptFile>();
 	}
 
 	std::string LoadJSON(const FilePath& fname) {

--- a/client/test-data.cpp
+++ b/client/test-data.cpp
@@ -26,28 +26,6 @@
 #include "events.hpp"
 
 namespace tec {
-	// Remove below by fixing the above todos
-	std::map<tid, std::function<void(const proto::Entity&, const proto::Component&)>> in_functors;
-	std::map<tid, std::function<void(const proto::Entity&, const proto::Component&, const state_id_t)>> update_functors;
-
-	template <typename T>
-	void AddInOutFunctors() {
-		in_functors[GetTypeID<T>()] = [](const proto::Entity& entity, const proto::Component& proto_comp) {
-			T* comp = new T();
-			comp->In(proto_comp);
-			Multiton<eid, T*>::Set(entity.id(), comp);
-		};
-		update_functors[GetTypeID<T>()] = [](const proto::Entity& entity, const proto::Component& proto_comp, const state_id_t) {
-			T* comp = new T();
-			comp->In(proto_comp);
-			Multiton<eid, T*>::Set(entity.id(), comp);
-		};
-	}
-
-	void InitializeComponents() {
-		AddInOutFunctors<Scale>();
-	}
-
 	void BuildTestEntities() {
 		auto voxvol = VoxelVolume::Create(1000, "bob");
 		auto voxvol_shared = voxvol.lock();
@@ -105,14 +83,6 @@ namespace tec {
 		google::protobuf::util::JsonStringToMessage(json_string, &data->entity);
 		data->entity_id = data->entity.id();
 		EventSystem<EntityCreated>::Get()->Emit(data);
-
-		// TODO: remove when above todos are done
-		for (int i = 0; i < data->entity.components_size(); ++i) {
-			const proto::Component& comp = data->entity.components(i);
-			if (in_functors.find(comp.component_case()) != in_functors.end()) {
-				in_functors[comp.component_case()](data->entity, comp);
-			}
-		}
 	}
 
 	void ProtoLoad(std::string filename) {

--- a/client/voxel-volume.hpp
+++ b/client/voxel-volume.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <unordered_map>
-#include <map>
 #include <memory>
 #include <vector>
 #include <queue>

--- a/common/components/lua-script.cpp
+++ b/common/components/lua-script.cpp
@@ -43,7 +43,7 @@ namespace tec {
 		comp->set_script_name(this->script_name);
 	}
 
-	extern std::map<std::string, std::function<void(std::string)>> file_factories;
+	extern std::unordered_map<std::string, std::function<void(std::string)>> file_factories;
 
 	void LuaScript::In(const proto::Component& source) {
 		const proto::LuaScript& comp = source.luascript();

--- a/common/components/lua-script.cpp
+++ b/common/components/lua-script.cpp
@@ -10,8 +10,6 @@
 #include "resources/script-file.hpp"
 
 namespace tec {
-	extern std::map<tid, std::function<void(const proto::Entity&, const proto::Component&)>> in_functors;
-
 	LuaScript::LuaScript()
 		: state() {
 		this->ReloadScript();
@@ -30,11 +28,11 @@ namespace tec {
 				spdlog::get("console_log")->info(str1); //, str2, str3, str4);
 			};
 			this->state["print"] = print;
-			for (auto& add_kv : in_functors) {
+			/*for (auto& add_kv : in_functors) {
 				std::string name = TypeName.at(add_kv.first);
 				name = "add" + name;
 				this->state[name.c_str()] = add_kv.second;
-			}
+			}*/
 
 			this->state.Load(this->script->GetScript());
 		}

--- a/common/physics-system.cpp
+++ b/common/physics-system.cpp
@@ -58,7 +58,6 @@ namespace tec {
 	}
 
 	std::set<eid> PhysicsSystem::Update(const double delta, const GameState& state) {
-		std::set<eid> updated_entities;
 		ProcessCommandQueue();
 		EventQueue<MouseBtnEvent>::ProcessEventQueue();
 		EventQueue<EntityCreated>::ProcessEventQueue();
@@ -123,6 +122,7 @@ namespace tec {
 
 		this->dynamicsWorld->stepSimulation(static_cast<btScalar>(delta), 10);
 
+		std::set<eid> updated_entities;
 		for (auto itr = CollisionBodyMap::Begin(); itr != CollisionBodyMap::End(); ++itr) {
 			auto entity_id = itr->first;
 			if (itr->second->motion_state.transform_updated) {

--- a/common/types.hpp
+++ b/common/types.hpp
@@ -34,7 +34,7 @@ namespace tec {
 	template<class TYPE> constexpr const char* GetTypeEXT(void) { return "UNKNOWN"; }
 
 	/*
-	 * Use this macro to associate a component to an type id and generat a string withthe name
+	 * Use this macro to associate a component to an type id and generate a string with the name
 	 * Only works if the struct and component name on .proto file are the same (see the list on message Component )
 	 */
 #define MAKE_IDTYPE(a) \


### PR DESCRIPTION
PR #160 should be merged first to fix build errors.

This removed more of test_data and the concept of the in/out functors in an effort to reduce paths that entity creation/updating can diverge or get out of sync.