### PR TITLE
Created config scripts loading, defaults to scripts/config.lua

### DIFF
--- a/client/game.cpp
+++ b/client/game.cpp
@@ -1,6 +1,7 @@
 #include "game.hpp"
 
 #include <devices/tda.hpp>
+#include <default-config.hpp>
 
 #include "controllers/fps-controller.hpp"
 #include "server-message.hpp"
@@ -51,8 +52,8 @@ namespace tec {
 
 	void Game::Startup() {
 		this->rs.Startup();
-		const unsigned int window_width = this->config_script->environment.get_or("window_width", 800);
-		const unsigned int window_height = this->config_script->environment.get_or("window_height", 800);
+		const unsigned int window_width = this->config_script->environment.get_or("window_width", WINDOW_WIDTH);
+		const unsigned int window_height = this->config_script->environment.get_or("window_height", WINDOW_HEIGHT);
 		this->rs.SetViewportSize(window_width, window_height);
 	}
 

--- a/client/game.hpp
+++ b/client/game.hpp
@@ -25,9 +25,11 @@ namespace tec {
 
 	class Game {
 	public:
-		Game(const unsigned int viewport_width, const unsigned int viewport_height);
+		Game(std::string config_file_name = "scripts/config.lua");
 
 		~Game();
+
+		void Startup();
 
 		void Update(double delta, double mouse_x, double mouse_y, int window_width, int window_height);
 
@@ -42,6 +44,8 @@ namespace tec {
 		LuaSystem* GetLuaSystem() {
 			return &this->lua_sys;
 		}
+
+		std::shared_ptr<LuaScript> config_script;
 
 	private:
 		static void UpdateVComputerScreenTextures();

--- a/client/graphics/gbuffer.cpp
+++ b/client/graphics/gbuffer.cpp
@@ -4,10 +4,10 @@
 #include "gbuffer.hpp"
 
 namespace tec {
-	GBuffer::GBuffer() {
-		glGenFramebuffers(1, &this->frame_buffer_object);
-	}
 	void GBuffer::AddColorAttachments(const unsigned int window_width, const unsigned int window_height) {
+		if (this->frame_buffer_object == 0) {
+			glGenFramebuffers(1, &this->frame_buffer_object);
+		}
 		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, this->frame_buffer_object);
 		glGenTextures(this->num_color_textures, this->color_textures);
 		glGenTextures(1, &this->final_texture);

--- a/client/graphics/gbuffer.hpp
+++ b/client/graphics/gbuffer.hpp
@@ -23,7 +23,7 @@ namespace tec {
 			GBUFFER_DEPTH_TYPE_STENCIL
 		};
 
-		GBuffer();
+		GBuffer() {}
 		~GBuffer() {}
 		void AddColorAttachments(const unsigned int window_width, const unsigned int window_height);
 		void ResizeColorAttachments(const unsigned int window_width, const unsigned int window_height);

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -51,6 +51,10 @@ auto ParseLogLevel(int argc, char* argv[]) {
 	return loglevel;
 }
 
+const unsigned int WINDOW_WIDTH = 1024;
+const unsigned int WINDOW_HEIGHT = 768;
+const std::string ASPECT_RATIO = "16:9";
+
 int main(int argc, char* argv[]) {
 	tec::Console console;
 
@@ -58,22 +62,31 @@ int main(int argc, char* argv[]) {
 
 	log->info(std::string("Asset path: ") + tec::FilePath::GetAssetsBasePath().toString());
 
+	tec::Game game;
+
+	const unsigned int window_width = game.config_script->environment.get_or("window_width", WINDOW_WIDTH);
+	const unsigned int window_height = game.config_script->environment.get_or("window_height", WINDOW_HEIGHT);
+
 	log->info("Initializing OpenGL...");
 	tec::OS os;
-	if (!os.InitializeWindow(1024, 768, "TEC 0.1", 4, 0)) {
+	if (!os.InitializeWindow(window_width, window_height, "TEC 0.1", 4, 0)) {
 		log->info("Exiting. The context wasn't created properly please update drivers and try again.");
 		exit(1);
 	}
+
+	const std::string aspect_ratio = game.config_script->environment.get_or("aspect_ratio", ASPECT_RATIO);
+	auto numer = stoi(aspect_ratio.substr(0, aspect_ratio.find(':')));
+	auto denom = stoi(aspect_ratio.substr(aspect_ratio.find(':') + 1));
+	os.SetWindowAspectRatio(numer, denom);
 	console.AddConsoleCommand(
 		"exit",
 		"exit : Exit from TEC",
 		[&os] (const char*) {
 			os.Quit();
 		});
+	game.Startup();
 
-	tec::Game game(os.GetWindowWidth(), os.GetWindowHeight());
 	tec::ActiveEntityTooltip active_entity_tooltip(game);
-
 	tec::networking::ServerConnection& connection = game.GetServerConnection();
 	tec::ServerConnectWindow server_connect_window(connection);
 	tec::PingTimesWindow ping_times_window(connection);

--- a/client/os.cpp
+++ b/client/os.cpp
@@ -171,6 +171,10 @@ namespace tec {
 		glfwMakeContextCurrent(this->window);
 	}
 
+	void OS::SetWindowAspectRatio(const unsigned int numerator, const unsigned int denominator) {
+		glfwSetWindowAspectRatio(this->window, numerator, denominator);
+	}
+
 	GLFWmonitor* get_current_monitor(GLFWwindow* window) {
 		int nmonitors, i;
 		int wx, wy, ww, wh;

--- a/client/os.hpp
+++ b/client/os.hpp
@@ -46,6 +46,11 @@ namespace tec {
 		*/
 		void MakeCurrent();
 
+		/** \brief Sets the desired window aspect ratio numerator:denominator e.g. 16:9, 4:3
+		*
+		*/
+		void SetWindowAspectRatio(const unsigned int numerator = 16, const unsigned int denominator = 9);
+
 		/** \brief Toggles between fullscreen and windowed mode based.
 		*
 		*/

--- a/client/render-system.cpp
+++ b/client/render-system.cpp
@@ -34,7 +34,7 @@ namespace tec {
 	using AnimationMap = Multiton<eid, Animation*>;
 	using ScaleMap = Multiton<eid, Scale*>;
 
-	RenderSystem::RenderSystem() {
+	void RenderSystem::Startup() {
 		_log = spdlog::get("console_log");
 
 		GLenum err = glGetError();

--- a/client/render-system.hpp
+++ b/client/render-system.hpp
@@ -41,7 +41,7 @@ namespace tec {
 		public EventQueue<WindowResizedEvent>,
 		public EventQueue<EntityDestroyed>, public EventQueue<EntityCreated> {
 	public:
-		RenderSystem();
+		void Startup();
 
 		void SetViewportSize(const unsigned int width, const unsigned int height);
 

--- a/common/components/lua-script.cpp
+++ b/common/components/lua-script.cpp
@@ -19,9 +19,9 @@ namespace tec {
 		this->ReloadScript();
 	}
 
-	void LuaScript::SetupEnvironment(sol::state* global_state) {
-		this->global_state = global_state;
-		this->environment = sol::environment(*global_state, sol::create, global_state->globals());
+	void LuaScript::SetupEnvironment(sol::state* _global_state) {
+		this->global_state = _global_state;
+		this->environment = sol::environment(*this->global_state, sol::create, this->global_state->globals());
 	}
 
 	void LuaScript::ReloadScript() {

--- a/common/components/lua-script.hpp
+++ b/common/components/lua-script.hpp
@@ -28,6 +28,6 @@ namespace tec {
 		std::shared_ptr<ScriptFile> script;
 
 		sol::environment environment;
-		sol::state* global_state;
+		sol::state* global_state = nullptr;
 	};
 }

--- a/common/default-config.hpp
+++ b/common/default-config.hpp
@@ -1,0 +1,4 @@
+#pragma once
+
+const unsigned int WINDOW_WIDTH = 1024;
+const unsigned int WINDOW_HEIGHT = 768;

--- a/common/lua-system.cpp
+++ b/common/lua-system.cpp
@@ -6,13 +6,13 @@
 #include "entity.hpp"
 #include "events.hpp"
 #include "multiton.hpp"
-#include "components/lua-script.hpp"
+#include "resources/script-file.hpp"
 
 namespace tec {
 	using LuaScriptMap = Multiton<eid, LuaScript*>;
 
 	LuaSystem::LuaSystem() {
-		this->lua.open_libraries(sol::lib::base, sol::lib::package);
+		this->lua.open_libraries(sol::lib::base, sol::lib::package, sol::lib::table);
 
 		this->lua["print"] = [] (std::string str) {
 			spdlog::get("console_log")->info(str);
@@ -63,6 +63,13 @@ namespace tec {
 				break;
 			}
 		}
+	}
+
+	std::shared_ptr<LuaScript> LuaSystem::LoadFile(FilePath filepath) {
+		std::shared_ptr<LuaScript> script = std::make_shared<LuaScript>(ScriptFile::Create(filepath));
+		script->SetupEnvironment(&this->lua);
+		script->ReloadScript();
+		return script;
 	}
 
 	void LuaSystem::On(std::shared_ptr<EntityDestroyed> data) {

--- a/common/lua-system.hpp
+++ b/common/lua-system.hpp
@@ -12,6 +12,8 @@
 #include "types.hpp"
 #include "event-system.hpp"
 #include "command-queue.hpp"
+#include "filesystem.hpp"
+#include "components/lua-script.hpp"
 
 namespace tec {
 	class LuaSystem;
@@ -33,6 +35,8 @@ namespace tec {
 		void On(std::shared_ptr<EntityDestroyed> data);
 
 		void ExecuteString(std::string script_string);
+
+		std::shared_ptr<LuaScript> LoadFile(FilePath filepath);
 
 		sol::state& GetGlobalState() {
 			return this->lua;


### PR DESCRIPTION
Tweaked order of render system initialization to support loading config before attempting to create GL objects.

This config script can be acceessed to get values such as graphics options.

Closes #13 