### PR TITLE
Add the ability to give a computer keyboard focus and prevent controllers from acting on that input

### DIFF
--- a/common/controllers/fps-controller.cpp
+++ b/common/controllers/fps-controller.cpp
@@ -17,14 +17,18 @@ namespace tec {
 			return;
 		}
 		this->current_delta = delta;
-		for (const KeyboardEvent& key_event : commands.keyboard_events) {
-			Handle(key_event, state);
+		if (keyboard_focus) {
+			for (const KeyboardEvent& key_event : commands.keyboard_events) {
+				Handle(key_event, state);
+			}
 		}
-		for (const MouseBtnEvent& mouse_button_event : commands.mouse_button_events) {
-			Handle(mouse_button_event, state);
-		}
-		for (const MouseMoveEvent& mouse_move_event : commands.mouse_move_events) {
-			Handle(mouse_move_event, state);
+		if (mouse_focus) {
+			for (const MouseBtnEvent& mouse_button_event : commands.mouse_button_events) {
+				Handle(mouse_button_event, state);
+			}
+			for (const MouseMoveEvent& mouse_move_event : commands.mouse_move_events) {
+				Handle(mouse_move_event, state);
+			}
 		}
 
 		int forwardDirection = 0;

--- a/common/controllers/fps-controller.hpp
+++ b/common/controllers/fps-controller.hpp
@@ -22,7 +22,14 @@ namespace tec {
 
 		virtual void ApplyClientCommands(proto::ClientCommands) = 0;
 
+		void SetFocus(bool keyboard, bool mouse) {
+			this->keyboard_focus = keyboard;
+			this->mouse_focus = mouse;
+		}
+
 		eid entity_id;
+		bool keyboard_focus = true;
+		bool mouse_focus = true;
 	};
 
 	// TODO: Remove this class as it is only for testing and should really be

--- a/common/events.hpp
+++ b/common/events.hpp
@@ -74,5 +74,14 @@ namespace tec {
 	struct ControllerRemovedEvent {
 		std::shared_ptr<Controller> controller{nullptr};
 	};
-
+	struct FocusCapturedEvent {
+		eid entity_id;
+		bool keyboard;
+		bool mouse;
+	};
+	struct FocusBlurEvent {
+		eid entity_id;
+		bool keyboard;
+		bool mouse;
+	};
 }

--- a/common/simulation.cpp
+++ b/common/simulation.cpp
@@ -22,10 +22,12 @@ namespace tec {
 		EventQueue<ClientCommandsEvent>::ProcessEventQueue();
 		EventQueue<ControllerAddedEvent>::ProcessEventQueue();
 		EventQueue<ControllerRemovedEvent>::ProcessEventQueue();
+		EventQueue<FocusCapturedEvent>::ProcessEventQueue();
+		EventQueue<FocusBlurEvent>::ProcessEventQueue();
 
 		auto vcomp_future = std::async(std::launch::async, [&] () {
 			vcomp_sys.Update(delta_time);
-									   });
+			});
 
 		for (Controller* controller : this->controllers) {
 			controller->Update(delta_time, interpolated_state, this->event_list);
@@ -87,6 +89,18 @@ namespace tec {
 
 	void Simulation::On(std::shared_ptr<ControllerRemovedEvent> data) {
 		RemoveController(data->controller.get());
+	}
+
+	void Simulation::On(std::shared_ptr<FocusCapturedEvent> data) {
+		for (Controller* controller : this->controllers) {
+			controller->SetFocus(!data->keyboard, !data->mouse);
+		}
+	}
+
+	void Simulation::On(std::shared_ptr<FocusBlurEvent> data) {
+		for (Controller* controller : this->controllers) {
+			controller->SetFocus(data->keyboard, data->mouse);
+		}
 	}
 
 	void Simulation::On(std::shared_ptr<ClientCommandsEvent> data) {

--- a/common/simulation.hpp
+++ b/common/simulation.hpp
@@ -24,7 +24,8 @@ namespace tec {
 		public EventQueue<KeyboardEvent>, public EventQueue<MouseBtnEvent>,
 		public EventQueue<MouseMoveEvent>, public EventQueue<MouseClickEvent>,
 		public EventQueue<ClientCommandsEvent>, public EventQueue<ControllerAddedEvent>,
-		public EventQueue<ControllerRemovedEvent> {
+		public EventQueue<ControllerRemovedEvent>, public EventQueue<FocusCapturedEvent>,
+		public EventQueue<FocusBlurEvent> {
 	public:
 		GameState Simulate(const double delta_time, GameState& interpolated_state);
 
@@ -53,6 +54,8 @@ namespace tec {
 		void On(std::shared_ptr<ClientCommandsEvent> data);
 		void On(std::shared_ptr<ControllerAddedEvent> data);
 		void On(std::shared_ptr<ControllerRemovedEvent> data);
+		void On(std::shared_ptr<FocusCapturedEvent> data);
+		void On(std::shared_ptr<FocusBlurEvent> data);
 	private:
 		PhysicsSystem phys_sys;
 		VComputerSystem vcomp_sys;

--- a/common/vcomputer-system.hpp
+++ b/common/vcomputer-system.hpp
@@ -69,6 +69,7 @@ namespace tec {
 
 	struct KeyboardEvent;
 	struct MouseBtnEvent;
+	struct MouseClickEvent;
 	struct EntityCreated;
 	struct EntityDestroyed;
 
@@ -76,6 +77,7 @@ namespace tec {
 		public CommandQueue<VComputerSystem>,
 		public EventQueue<KeyboardEvent>,
 		public EventQueue<MouseBtnEvent>,
+		public EventQueue<MouseClickEvent>,
 		public EventQueue < EntityCreated >,
 		public EventQueue < EntityDestroyed > {
 	public:
@@ -129,10 +131,12 @@ namespace tec {
 
 		using EventQueue<KeyboardEvent>::On;
 		using EventQueue<MouseBtnEvent>::On;
+		using EventQueue<MouseClickEvent>::On;
 		using EventQueue<EntityCreated>::On;
 		using EventQueue<EntityDestroyed>::On;
 		void On(std::shared_ptr<KeyboardEvent> data);
 		void On(std::shared_ptr<MouseBtnEvent> data);
+		void On(std::shared_ptr<MouseClickEvent> data);
 		void On(std::shared_ptr<EntityCreated> data);
 		void On(std::shared_ptr<EntityDestroyed> data);
 	private:


### PR DESCRIPTION
This will give the ability to click on a entity and have the entity send out a focus captured and blur (no longer has focus) event, and applies this event dispatch to the vcomputer.

## Description
There is now 2 new events FocusCaptured and FocusBlurred that indicate which entity has generated the event and which form of input that have captured or blurred.

The VComputer now listens for entity clicked events and if a click is on a computer with a keyboard it sends a FocusCaptured. Upon hitting the ESCAPE key an appropriate FocusBlurred event is sent out.

The simulation listens for these events and sets a flag on all controllers indicated if they have keyboard/mouse focus or not.

## Motivation and Context
Users need a way to interact with the computers, and there was no mechanism to stop the user from moving during input, nor was there a way to send input to a computer.

## How Has This Been Tested?
I connected to the server, moved to the computer with the black screen and AAAA on it in the world and clicked on it. After clicking on it I was able to see my characters appear on the computers screen. Clicking the other computer with the mostly red screen caused key to no longer appear on the first computer, but I was still unable to move around which proves that movement is lost when a computer has focus. Finally hitting the ESCAPE key caused movement to return and input to no longer be sent to the comptuer.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
