### PR TITLE
Move file factory creation into a header so it can be instantiated in both client and server

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -23,7 +23,6 @@ endif ()
 set(trillek-client_SOURCES # don't include main.cpp to keep it out of tests
 	${trillek-client_SOURCE_DIR}/game.cpp
 	${trillek-client_SOURCE_DIR}/imgui-system.cpp
-	${trillek-client_SOURCE_DIR}/file-factories.cpp
 	${trillek-client_SOURCE_DIR}/os.cpp
 	${trillek-client_SOURCE_DIR}/render-system.cpp
 	${trillek-client_SOURCE_DIR}/server-connection.cpp

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -5,6 +5,7 @@
 #include <thread>
 
 #include <default-config.hpp>
+#include <file-factories.hpp>
 
 #include "game.hpp"
 
@@ -17,11 +18,23 @@
 #include "imgui-system.hpp"
 #include "os.hpp"
 
+#include "resources/md5mesh.hpp"
+#include "resources/obj.hpp"
+#include "resources/md5anim.hpp"
+#include "resources/vorbis-stream.hpp"
+#include "resources/script-file.hpp"
+
 #include <spdlog/spdlog.h>
 #include <spdlog/sinks/stdout_sinks.h>
 
 namespace tec {
-	extern void InitializeFileFactories();
+	void RegisterFileFactories() {
+		AddFileFactory<MD5Mesh>();
+		AddFileFactory<MD5Anim>();
+		AddFileFactory<OBJ>();
+		AddFileFactory<VorbisStream>();
+		AddFileFactory<ScriptFile>();
+	}
 	extern void BuildTestVoxelVolume();
 	extern void ProtoLoad(std::string filename);
 }
@@ -144,7 +157,7 @@ int main(int argc, char* argv[]) {
 	tec::LuaSystem* lua_sys = game.GetLuaSystem();
 	os.LuaStateRegistration(lua_sys->GetGlobalState());
 
-	tec::InitializeFileFactories();
+	tec::RegisterFileFactories();
 	tec::BuildTestVoxelVolume();
 	tec::ProtoLoad("json/test.json");
 

--- a/common/file-factories.hpp
+++ b/common/file-factories.hpp
@@ -1,18 +1,14 @@
+#pragma once
+
 #include <functional>
 #include <unordered_map>
-
-#include "resources/md5mesh.hpp"
-#include "resources/obj.hpp"
-#include "resources/md5anim.hpp"
-#include "resources/vorbis-stream.hpp"
-#include "resources/script-file.hpp"
 
 #include "tec-types.hpp"
 #include "filesystem.hpp"
 
 namespace tec {
 	std::unordered_map<std::string, std::function<void(std::string)>> file_factories;
-	template <typename T>
+	template <typename T> 
 	void AddFileFactory() {
 		file_factories[GetTypeEXT<T>()] = [] (std::string fname) {
 			FilePath path(fname);
@@ -23,13 +19,5 @@ namespace tec {
 				T::Create(FilePath::GetAssetPath(fname));
 			}
 		};
-	}
-
-	void InitializeFileFactories() {
-		AddFileFactory<MD5Mesh>();
-		AddFileFactory<MD5Anim>();
-		AddFileFactory<OBJ>();
-		AddFileFactory<VorbisStream>();
-		AddFileFactory<ScriptFile>();
 	}
 }

--- a/common/simulation.hpp
+++ b/common/simulation.hpp
@@ -47,15 +47,15 @@ namespace tec {
 		using EventQueue<ClientCommandsEvent>::On;
 		using EventQueue<ControllerAddedEvent>::On;
 		using EventQueue<ControllerRemovedEvent>::On;
-		void On(std::shared_ptr<KeyboardEvent> data);
-		void On(std::shared_ptr<MouseBtnEvent> data);
-		void On(std::shared_ptr<MouseMoveEvent> data);
-		void On(std::shared_ptr<MouseClickEvent> data);
-		void On(std::shared_ptr<ClientCommandsEvent> data);
-		void On(std::shared_ptr<ControllerAddedEvent> data);
-		void On(std::shared_ptr<ControllerRemovedEvent> data);
-		void On(std::shared_ptr<FocusCapturedEvent> data);
-		void On(std::shared_ptr<FocusBlurEvent> data);
+		void On(std::shared_ptr<KeyboardEvent> data) override;
+		void On(std::shared_ptr<MouseBtnEvent> data) override;
+		void On(std::shared_ptr<MouseMoveEvent> data) override;
+		void On(std::shared_ptr<MouseClickEvent> data) override;
+		void On(std::shared_ptr<ClientCommandsEvent> data) override;
+		void On(std::shared_ptr<ControllerAddedEvent> data) override;
+		void On(std::shared_ptr<ControllerRemovedEvent> data) override;
+		void On(std::shared_ptr<FocusCapturedEvent> data) override;
+		void On(std::shared_ptr<FocusBlurEvent> data) override;
 	private:
 		PhysicsSystem phys_sys;
 		VComputerSystem vcomp_sys;

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -8,17 +8,24 @@
 #include <google/protobuf/util/json_util.h>
 #include <game_state.pb.h>
 
+#include <file-factories.hpp>
+
 #include "filesystem.hpp"
 #include "server.hpp"
 #include "client-connection.hpp"
 #include "game-state-queue.hpp"
 #include "simulation.hpp"
 
+#include "resources/script-file.hpp"
+
 using asio::ip::tcp;
 
 tec::state_id_t current_state_id = 0;
 
 namespace tec {
+	void RegisterFileFactories() {
+		AddFileFactory<ScriptFile>();
+	}
 	std::string LoadJSON(const FilePath& fname) {
 		std::fstream input(fname.GetNativePath(), std::ios::in | std::ios::binary);
 		if (!input.good())
@@ -43,6 +50,7 @@ namespace tec {
 }
 
 int main() {
+	tec::RegisterFileFactories();
 	std::chrono::high_resolution_clock::time_point last_time, next_time;
 	std::chrono::duration<double> elapsed_seconds;
 	bool closing = false;


### PR DESCRIPTION
This relocates the file factory map and registration function to a header in the common project. By having it here an instance of the map will be created in all projects that link to tec. Each project must add file factories respectively to it's map by calling AddFileFactory.
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Currently the server is unable to have an instance of LuaSystem because it cannot locate the file factories.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Both client and server compile and run.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


Fixed a few compiler warnings about simulation not specifying the override keyword in Simulation.