### PR TITLE
Make the VM keyboard send the correct codes

### DIFF
--- a/common/proto/components.proto
+++ b/common/proto/components.proto
@@ -107,8 +107,8 @@ message VoxelVolumen {
 }
 
 message ComputerScreen {
-	required bytes text_buffer = 1;
-	required bytes font_buffer = 2;
+	optional bytes text_buffer = 1;
+	optional bytes font_buffer = 2;
 	required uint32 buffer_ptr = 3;
 	required uint32 font_ptr = 4;
 	required uint32 vsync_msg = 5;

--- a/common/vcomputer-system.hpp
+++ b/common/vcomputer-system.hpp
@@ -61,6 +61,8 @@ struct ComputerKeyboard : DeviceBase {
 	virtual ~ComputerKeyboard() = default;
 
 	bool has_focus{false};
+	int last_keycode{0};
+	int modifiers_state{0};
 
 	void In(const proto::Computer::Device& source);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changes the Virtual Keyboard's event method to send keycodes according to the keyboard spec

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The virtual computer keyboard is supposed to decode characters and provide info about various control codes, it was not/or was wrong.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by writing a TR3200 program that initialized the virtual keyboard and displayed the keycodes and VK "scancodes"
All of visible ASCII, space, return, and backspace, were tested.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
