### PR TITLE
catch GL frame errors, fix errors from a stencil call on Intel/OSX, fixes #192

### DIFF
--- a/client/main.cpp
+++ b/client/main.cpp
@@ -96,11 +96,15 @@ int main(int argc, char* argv[]) {
 
 	const unsigned int window_width = game.config_script->environment.get_or("window_width", WINDOW_WIDTH);
 	const unsigned int window_height = game.config_script->environment.get_or("window_height", WINDOW_HEIGHT);
+	std::string window_title = "Trillek Engine 0.1";
 
 	log->info("Initializing OpenGL...");
-	if (!os.InitializeWindow(window_width, window_height, "TEC 0.1", 4, 0)) {
-		log->info("Exiting. The context wasn't created properly please update drivers and try again.");
-		exit(1);
+	if (!os.InitializeWindow(window_width, window_height, window_title, 4, 0)) {
+		log->warn("The OpenGL 4.0 context wasn't created properly, attempting fallback");
+		if (!os.InitializeWindow(window_width, window_height, window_title, 3, 3)) {
+			log->error("Exiting. Can not create OpenGL 4.0 or 3.3 context. please update drivers and try again.");
+			exit(1);
+		}
 	}
 
 	const std::string default_aspect_ratio = CalculateAspectRatioString(window_width, window_height);

--- a/client/render-system.cpp
+++ b/client/render-system.cpp
@@ -106,6 +106,9 @@ void RenderSystem::Update(const double delta, const GameState& state) {
 	EventQueue<EntityCreated>::ProcessEventQueue();
 	EventQueue<EntityDestroyed>::ProcessEventQueue();
 
+	GLenum err;
+	err = glGetError();
+	if(err) { _log->debug("[GL] Preframe error {}", err); }
 	UpdateRenderList(delta, state);
 	this->light_gbuffer.StartFrame();
 
@@ -119,6 +122,8 @@ void RenderSystem::Update(const double delta, const GameState& state) {
 
 	FinalPass();
 	// RenderGbuffer();
+	err = glGetError();
+	if(err) { _log->debug("[GL] Postframe error {}", err); }
 }
 
 void RenderSystem::GeometryPass() {
@@ -448,6 +453,7 @@ void RenderSystem::SetupDefaultShaders() {
 
 	auto deferred_stencil_shader_files = std::list<std::pair<Shader::ShaderType, FilePath>>{
 			std::make_pair(Shader::VERTEX, FilePath::GetAssetPath("shaders/deferred_light.vert")),
+			std::make_pair(Shader::FRAGMENT, FilePath::GetAssetPath("shaders/deferred_stencil.frag")),
 	};
 	auto deferred_stencil_shader = Shader::CreateFromFile("deferred_stencil", deferred_stencil_shader_files);
 
@@ -607,3 +613,4 @@ void RenderSystem::UpdateRenderList(double delta, const GameState& state) {
 	}
 }
 } // namespace tec
+

--- a/client/render-system.cpp
+++ b/client/render-system.cpp
@@ -108,7 +108,9 @@ void RenderSystem::Update(const double delta, const GameState& state) {
 
 	GLenum err;
 	err = glGetError();
-	if(err) { _log->debug("[GL] Preframe error {}", err); }
+	if (err) {
+		_log->debug("[GL] Preframe error {}", err);
+	}
 	UpdateRenderList(delta, state);
 	this->light_gbuffer.StartFrame();
 
@@ -123,7 +125,9 @@ void RenderSystem::Update(const double delta, const GameState& state) {
 	FinalPass();
 	// RenderGbuffer();
 	err = glGetError();
-	if(err) { _log->debug("[GL] Postframe error {}", err); }
+	if (err) {
+		_log->debug("[GL] Postframe error {}", err);
+	}
 }
 
 void RenderSystem::GeometryPass() {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adds calls to glGetError at the beginning and end of frames to prevent them from leaking into other calls.
Adds the ability to fallback to OpenGL 3.3, if the 4.0 isn't supported (because I hate manually patching this in every time).
Fixes a GL error where the GL requires a fragment shader in a pure stencil/depth pipeline.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See issue (https://github.com/trillek-team/tec/issues/192)
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Built and run on MacOS 10.12.6, with Intel HD Graphics 3000 (GL 3.3) - The virtual computer in entity 101 rendered it's screen.
With verbose flag "-v" no GL errors reported.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
