### PR TITLE
Add checks to ensure an audio file was loaded, otherwise don't create the component

### DIFF
--- a/client/sound-system.cpp
+++ b/client/sound-system.cpp
@@ -105,7 +105,12 @@ void SoundSystem::On(std::shared_ptr<EntityCreated> data) {
 		{
 			AudioSource* audio_source = new AudioSource();
 			audio_source->In(comp);
-			AudioSourceComponentMap::Set(entity_id, audio_source);
+			if (audio_source->vorbis_stream) {
+				AudioSourceComponentMap::Set(entity_id, audio_source);
+			}
+			else {
+				delete audio_source;
+			}
 		} break;
 		case proto::Component::kRenderable:
 		case proto::Component::kPointLight:

--- a/client/sound-system.hpp
+++ b/client/sound-system.hpp
@@ -47,7 +47,12 @@ struct AudioSource {
 					file_factories[ext](this->audio_name);
 				}
 			}
-			this->vorbis_stream = SoundMap::Get(this->audio_name);
+			if (SoundMap::Has(this->audio_name)) {
+				this->vorbis_stream = SoundMap::Get(this->audio_name);
+			}
+			else {
+				return;
+			}
 		}
 		if (comp.has_looping()) {
 			this->looping = comp.looping();


### PR DESCRIPTION
This commit simply adds a check when the audio file is attempting to load to verify it was loaded. If it wasn't then the component is not create and is not assigned to the respective entity.

A warning is emitted already that it failed to load the file before this PR.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
