### PR TITLE
Begin work on save system

### DIFF
--- a/client/main.cpp
+++ b/client/main.cpp
@@ -156,7 +156,6 @@ int main(int argc, char* argv[]) {
 
 	tec::RegisterFileFactories();
 	tec::BuildTestVoxelVolume();
-	tec::ProtoLoad("json/test.json");
 
 	console.AddConsoleCommand("lua", "lua : Execute a string in lua", [&lua_sys](const char* args) {
 		const char* end_arg = args;

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -17,6 +17,7 @@ include_directories(SYSTEM ${trillek_SOURCE_DIR}/deps/trillek-vcomputer/include)
 
 protobuf_generate_cpp(COMPONENTS_SOURCES COMPONENTS_HEADERS ${trillek-common_SOURCE_DIR}/proto/components.proto)
 protobuf_generate_cpp(GAME_STATE_SOURCES GAME_STATE_HEADERS ${trillek-common_SOURCE_DIR}/proto/game_state.proto)
+protobuf_generate_cpp(SAVE_GAME_SOURCES SAVE_GAME_HEADERS ${trillek-common_SOURCE_DIR}/proto/save_game.proto)
 protobuf_generate_cpp(COMMANDS_SOURCES COMMANDS_HEADERS ${trillek-common_SOURCE_DIR}/proto/commands.proto)
 
 set(trillek-common_LIBRARY "tec" CACHE STRING "Name of the library with code common to both the client and the server")
@@ -25,6 +26,7 @@ set(trillek-common_SOURCES
 	${trillek-common_SOURCE_DIR}/filesystem.cpp
 	${trillek-common_SOURCE_DIR}/lua-system.cpp
 	${trillek-common_SOURCE_DIR}/physics-system.cpp
+	${trillek-common_SOURCE_DIR}/save-game.cpp
 	${trillek-common_SOURCE_DIR}/simulation.cpp
 	${trillek-common_SOURCE_DIR}/string.cpp
 	${trillek-common_SOURCE_DIR}/tec-types.cpp
@@ -49,6 +51,7 @@ add_library(${trillek-common_LIBRARY} STATIC
 	${COMPONENTS_SOURCES}
 	${GAME_STATE_SOURCES}
 	${COMMANDS_SOURCES}
+	${SAVE_GAME_SOURCES}
 	${trillek-common_SOURCES}
 	${trillek-common_HEADERS}
 	${trillek-common_PROTOCOLS}

--- a/common/filesystem.cpp
+++ b/common/filesystem.cpp
@@ -38,11 +38,6 @@ namespace tec {
 const std::string app_name("trillek"); // TODO Ask to tec::OS for the app name ?
 const char UNIX_PATH_SEPARATOR = '/'; /// *NIX file system path separator
 const char WIN_PATH_SEPARATOR = '\\'; /// Windows file system path separator
-#if defined(__unix__)
-const std::string FilePath::PATH_SEPARATOR = std::string("\\");
-#else
-const std::string FilePath::PATH_SEPARATOR = std::string("/");
-#endif
 
 std::string FilePath::settings_folder = "";
 std::string FilePath::udata_folder = "";

--- a/common/filesystem.hpp
+++ b/common/filesystem.hpp
@@ -10,7 +10,7 @@
 #include <string>
 
 namespace tec {
-#if defined(__unix__)
+#if defined(WIN32)
 const std::string PATH_SEPARATOR = std::string("\\"); /// OS File system path separator
 #else
 const std::string PATH_SEPARATOR = std::string("/"); /// OS File system path separator

--- a/common/filesystem.hpp
+++ b/common/filesystem.hpp
@@ -10,9 +10,13 @@
 #include <string>
 
 namespace tec {
+#if defined(__unix__)
+const std::string PATH_SEPARATOR = std::string("\\"); /// OS File system path separator
+#else
+const std::string PATH_SEPARATOR = std::string("/"); /// OS File system path separator
+#endif
 class FilePath final {
 public:
-	const static std::string PATH_SEPARATOR; /// OS File system path separator
 #if defined(WIN32)
 	const static char PATH_SEPARATOR_C = '\\'; /// OS File system path separator
 	typedef std::wstring NFilePath; /// Native string format for paths

--- a/common/proto/save_game.proto
+++ b/common/proto/save_game.proto
@@ -1,0 +1,20 @@
+syntax = "proto2";
+
+package tec.proto;
+
+import "components.proto";
+
+message User {
+	required string id = 1;
+	required string username = 2;	
+	optional Position position = 3;
+}
+
+message World {
+	repeated string entity_file_list = 1;
+}
+
+message SaveGame {
+	repeated User users = 1;
+	required World world = 2;
+}

--- a/common/resources/script-file.hpp
+++ b/common/resources/script-file.hpp
@@ -46,28 +46,29 @@ public:
 	* \param[in] const FilePath filename The filename of the image file to load.
 	* \return bool True if initialization finished with no errors.
 	*/
-	bool Load(const FilePath& filename) {
+	bool Load(const FilePath& _filename) {
 		auto _log = spdlog::get("console_log");
-		if (filename.isValidPath() && filename.FileExists()) {
-			std::fstream file(filename.GetNativePath(), std::ios_base::in);
+		if (_filename.isValidPath() && _filename.FileExists()) {
+			std::fstream file(_filename.GetNativePath(), std::ios_base::in);
 			if (file.is_open()) {
 				file.seekg(0, std::ios::end);
 				script.reserve(static_cast<std::size_t>(file.tellg())); // Allocate string to the file size
 				file.seekg(0, std::ios::beg);
 
 				script = std::string((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
-				_log->trace("[Script] Read script file {} of {} bytes", filename.FileName(), script.length());
+				_log->trace("[Script] Read script file {} of {} bytes", _filename.FileName(), script.length());
+				this->filename = _filename;
 			}
 			else {
-				_log->warn("[Script] Error loading scriptfile {}", filename.FileName());
+				_log->warn("[Script] Error loading scriptfile {}", _filename.FileName());
 				return false;
 			}
 		}
 		else {
-			_log->warn("[Script] Error loading scriptfile {}. Invalid path.", filename.FileName());
+			_log->warn("[Script] Error loading scriptfile {}. Invalid path.", _filename.FileName());
 			return false;
 		}
-		_log->trace("[Script] Loaded scriptfile {}", filename.FileName());
+		_log->trace("[Script] Loaded scriptfile {}", _filename.FileName());
 		return true;
 	}
 
@@ -120,6 +121,7 @@ public:
 protected:
 	std::string name;
 	std::string script;
+	FilePath filename;
 	bool dirty{false};
 };
 } // namespace tec

--- a/common/save-game.cpp
+++ b/common/save-game.cpp
@@ -1,0 +1,147 @@
+#include "save-game.hpp"
+
+#include <algorithm>
+#include <fstream>
+#include <iterator>
+
+#include <google/protobuf/util/json_util.h>
+#include <spdlog/spdlog.h>
+
+#include "event-system.hpp"
+#include "events.hpp"
+
+namespace tec {
+template <typename T> void UserList::SetUsers(T begin, T end) { this->users.assign(begin, end); }
+
+void UserList::AddUser(proto::User user) { return this->users.push_back(user); }
+
+const std::vector<proto::User>* UserList::GetUsers() { return &this->users; }
+
+proto::User* UserList::GetUser(uid id) {
+	auto existing_user = this->GetUserItr(id);
+	if (existing_user != this->users.end()) {
+		return &*existing_user;
+	}
+	return nullptr;
+}
+
+bool UserList::RemoveUser(uid id) {
+	auto existing_user = this->GetUserItr(id);
+	if (existing_user != this->users.end()) {
+		this->users.erase(existing_user);
+		return true;
+	}
+	return false;
+}
+
+bool UserList::UserExists(uid id) { return this->GetUserItr(id) != this->users.end(); }
+
+std::vector<proto::User>::iterator UserList::GetUserItr(uid id) {
+	return std::find_if(this->users.begin(), this->users.end(), [id](proto::User user) { return user.id() == id; });
+}
+
+extern std::string LoadJSON(const FilePath& fname);
+
+bool SaveJSON(const FilePath& fname, std::string contents) {
+	std::fstream output(fname.GetNativePath(), std::ios::out);
+	if (!output.good())
+		throw std::runtime_error("can't open ." + fname.toString());
+
+	output.write(contents.c_str(), contents.length());
+	output.close();
+	return true;
+}
+
+bool SaveGame::Load(const FilePath _filepath) {
+	auto _log = spdlog::get("console_log");
+	this->filepath = _filepath;
+	if (_filepath.FileExists()) {
+		auto json_string = LoadJSON(this->filepath);
+		auto status = google::protobuf::util::JsonStringToMessage(json_string, &this->save);
+		if (status.ok()) {
+			this->LoadUsers();
+			this->LoadWorld();
+			return true;
+		}
+		_log->error("Failed to parse save data");
+		return false;
+	}
+
+	_log->error("File does not exist: {}", _filepath.FileName());
+	return false;
+}
+
+bool SaveGame::Save() { return this->Save(this->filepath); }
+
+bool SaveGame::Save(const FilePath _filepath) {
+	auto _log = spdlog::get("console_log");
+	if (_filepath.FileExists() || _filepath.isValidPath()) {
+		this->filepath = _filepath;
+		this->SaveUsers();
+		this->SaveWorld();
+
+		std::string json_string;
+
+		auto status = google::protobuf::util::MessageToJsonString(this->save, &json_string);
+
+		if (status.ok()) {
+			try {
+				SaveJSON(_filepath, json_string);
+			}
+			catch (std::runtime_error err) {
+				_log->error("Failed to save to file: {}", _filepath.FileName());
+			}
+			return true;
+		}
+		_log->error("Failed to serialize save data");
+		return false;
+	}
+	_log->error("File does not exist or path is invalid: {}", _filepath.toString());
+	return false;
+}
+
+UserList* SaveGame::GetUserList() { return &this->user_list; }
+
+void SaveGame::LoadUsers() {
+	auto users = this->save.mutable_users();
+	user_list.SetUsers(users->begin(), users->end());
+}
+
+void SaveGame::SaveUsers() {
+	auto users = this->save.mutable_users();
+	users->Clear();
+	for (const auto& user : *user_list.GetUsers()) {
+		auto save_user = users->Add();
+		save_user->CopyFrom(user);
+	}
+}
+
+void SaveGame::LoadWorld() {
+	auto _log = spdlog::get("console_log");
+	auto world = this->save.world();
+	for (int i = 0; i < world.entity_file_list_size(); i++) {
+		FilePath entity_filename = FilePath::GetAssetPath(world.entity_file_list(i));
+		if (entity_filename.isValidPath() && entity_filename.FileExists()) {
+			std::string json_string = LoadJSON(entity_filename);
+			proto::Entity entity;
+			auto status = google::protobuf::util::JsonStringToMessage(json_string, &entity);
+			if (status.ok()) {
+				EventSystem<EntityCreated>::Get()->Emit(
+						std::make_shared<EntityCreated>(EntityCreated{static_cast<eid>(entity.id()), entity}));
+			}
+			else {
+				_log->error("Failed to parse entity data");
+			}
+		}
+		else {
+			_log->error("File does not exist or path is invalid: {}", entity_filename.toString());
+		}
+	}
+}
+
+void SaveGame::SaveWorld() {
+	auto world = this->save.mutable_world();
+	// world->Clear();
+	// TODO: Find way to get active entities in the world and iterate over them
+}
+} // namespace tec

--- a/common/save-game.hpp
+++ b/common/save-game.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <vector>
+#include <list>
 
 #include <save_game.pb.h>
 
@@ -9,20 +9,23 @@
 #include "tec-types.hpp"
 
 namespace tec {
+// The follow is used to align the type used used for UserList operations
+// with the type defined in the proto file definition. E.g if id is if type
+// string in the .proto file, UserList::AddUser expects a string id parameter.
 using uid = decltype(proto::User().id());
 
 class UserList {
 public:
 	template <typename T> void SetUsers(T begin, T end);
 	void AddUser(proto::User);
-	const std::vector<proto::User>* GetUsers();
+	const std::list<proto::User>* GetUsers();
 	proto::User* GetUser(uid);
 	bool RemoveUser(uid);
 	bool UserExists(uid);
 
 private:
-	std::vector<proto::User> users;
-	std::vector<proto::User>::iterator GetUserItr(uid);
+	std::list<proto::User> users;
+	std::list<proto::User>::iterator GetUserItr(uid);
 };
 
 class SaveGame {

--- a/common/save-game.hpp
+++ b/common/save-game.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <vector>
+
+#include <save_game.pb.h>
+
+#include "filesystem.hpp"
+
+#include "tec-types.hpp"
+
+namespace tec {
+using uid = decltype(proto::User().id());
+
+class UserList {
+public:
+	template <typename T> void SetUsers(T begin, T end);
+	void AddUser(proto::User);
+	const std::vector<proto::User>* GetUsers();
+	proto::User* GetUser(uid);
+	bool RemoveUser(uid);
+	bool UserExists(uid);
+
+private:
+	std::vector<proto::User> users;
+	std::vector<proto::User>::iterator GetUserItr(uid);
+};
+
+class SaveGame {
+public:
+	bool Load(const FilePath);
+	bool Save();
+	bool Save(const FilePath);
+
+	UserList* GetUserList();
+
+private:
+	void LoadUsers();
+	void SaveUsers();
+	void LoadWorld();
+	void SaveWorld();
+
+	proto::SaveGame save;
+	FilePath filepath;
+	UserList user_list;
+};
+} // namespace tec

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <chrono>
 #include <fstream>
 #include <iostream>
@@ -18,6 +19,7 @@
 #include "simulation.hpp"
 
 #include "resources/script-file.hpp"
+#include <save-game.hpp>
 
 #include <spdlog/spdlog.h>
 #include <spdlog/sinks/stdout_sinks.h>
@@ -82,12 +84,18 @@ int main() {
 	// use constant mode stepping, because we don't need interpolated states on the server
 	simulation.GetPhysicsSystem().SetSubstepping(0);
 
+	tec::FilePath save_directory = tec::FilePath::GetAssetPath("save");
+
+	if (!save_directory.DirExists()) {
+		tec::FilePath::MkPath(save_directory);
+	}
+
 	try {
 		tcp::endpoint endpoint(asio::ip::tcp::v4(), tec::networking::PORT);
 		tec::networking::Server server(endpoint);
-		std::cout << "Server ready" << std::endl;
 
-		tec::ProtoLoadEntity(tec::FilePath::GetAssetPath("json/1000.json"));
+		tec::SaveGame save;
+		save.Load(tec::FilePath::GetAssetPath("save/save1.json"));
 
 		last_time = std::chrono::high_resolution_clock::now();
 		std::thread simulation_thread([&]() {

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -22,10 +22,10 @@ Server::Server(tcp::endpoint& endpoint) : acceptor(io_service, endpoint), socket
 	this->greeting_msg.SetBodyLength(message.size());
 	memcpy(this->greeting_msg.GetBodyPTR(), message.c_str(), this->greeting_msg.GetBodyLength());
 	this->greeting_msg.encode_header();
-  
+
 	// Load test script
 	FilePath fp = FilePath::GetAssetPath("scripts/server-test.lua");
-	if(fp.FileExists()){
+	if (fp.FileExists()) {
 		this->lua_sys.LoadFile(fp);
 	}
 
@@ -109,7 +109,7 @@ void Server::AcceptHandler() {
 			std::shared_ptr<ClientConnection> client = std::make_shared<ClientConnection>(std::move(socket), this);
 
 			// self_protopack does contain a renderable component
-			static FilePath others_protopack = FilePath::GetAssetPath("protopacks/others.proto");
+			static FilePath others_protopack = FilePath::GetAssetPath("protopacks/others.json");
 			proto::Entity other_entity;
 			LoadProtoPack(other_entity, others_protopack);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,9 +25,14 @@ set(trillek-test_PROGRAM "tests")
 set(trillek-test_SOURCES
 	client-server-connection.cpp
 	filesystem_test.cpp
+	save-game_test.cpp
 )
 
-add_executable(${trillek-test_PROGRAM} ${trillek-test_SOURCES} ${trillek-server_SOURCES} ${trillek-client_SOURCES})
+add_executable(${trillek-test_PROGRAM}
+	${trillek-test_SOURCES}
+	${trillek-server_SOURCES}
+	${trillek-client_SOURCES}
+)
 target_link_libraries(${trillek-test_PROGRAM} PRIVATE ${OPENGL_gl_LIBRARY} ${X11_LIBRARIES} ${OSX_LIBRARIES}
-	GTest::GTest GTest::Main GLEW::GLEW OpenAL::OpenAL glfw imgui::imgui  ${trillek-common_LIBRARY} VCOMPUTER_STATIC)
+	GTest::GTest GTest::Main GLEW::GLEW OpenAL::OpenAL glfw imgui::imgui ${trillek-common_LIBRARY} VCOMPUTER_STATIC)
 gtest_discover_tests(${trillek-test_PROGRAM})

--- a/tests/client-server-connection.cpp
+++ b/tests/client-server-connection.cpp
@@ -5,9 +5,11 @@
 #include <gtest/gtest.h>
 
 #include "client/server-connection.hpp"
+#include "server-stats.hpp"
 #include "server/server.hpp"
 #include "tec-types.hpp"
 #include <asio.hpp>
+#include <file-factories.hpp>
 #include <spdlog/sinks/stdout_sinks.h>
 #include <spdlog/spdlog.h>
 
@@ -23,7 +25,8 @@ TEST(ClientServerConnection_test, Constructor) {
 	std::promise<tec::eid> promise_client_id;
 	std::future<tec::eid> client_id = promise_client_id.get_future();
 
-	tec::networking::ServerConnection connection;
+	tec::ServerStats stats;
+	tec::networking::ServerConnection connection(stats);
 	std::shared_ptr<std::thread> asio_thread;
 
 	connection.RegisterMessageHandler(

--- a/tests/save-game_test.cpp
+++ b/tests/save-game_test.cpp
@@ -1,0 +1,127 @@
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+
+#include "save-game.hpp"
+
+using namespace tec;
+
+const FilePath save_directory = FilePath::GetAssetPath("save_test_123456");
+const FilePath save_file_path = save_directory + "/save.json";
+const std::string
+		contents("{\"users\":[{\"id\":\"user-1\",\"username\":\"John\"}], \"world\":{\"entityFileList\":[]}}");
+
+class SaveGameTest : public ::testing::Test {
+protected:
+	void SetUp() override {
+		ASSERT_TRUE(FilePath::MkDir(save_directory));
+		std::fstream output(save_file_path.GetNativePath(), std::ios::out);
+		ASSERT_TRUE(output.good());
+		output.write(contents.c_str(), contents.length());
+		output.close();
+	}
+
+	void TearDown() override {
+		try {
+			std::filesystem::remove_all(save_directory.toString());
+		}
+		catch (std::filesystem::filesystem_error err) {
+			std::cout << "Failed to clean up - " << err.code() << ":" << err.what() << std::endl;
+		}
+	}
+};
+TEST_F(SaveGameTest, Constructor) { SaveGame save_game; }
+
+TEST_F(SaveGameTest, DiskIO) {
+	// Sanity check
+	ASSERT_TRUE(save_directory.DirExists());
+
+	uid user2_id = "user-2";
+	{
+		SaveGame save_game;
+		EXPECT_NO_THROW(save_game.Load(save_file_path));
+		auto user2 = proto::User();
+		user2.set_id(user2_id);
+		user2.set_username(user2_id);
+		save_game.GetUserList()->AddUser(user2);
+		EXPECT_NO_THROW(save_game.Save());
+	}
+	{
+		SaveGame save_game;
+		save_game.Load(save_file_path);
+		EXPECT_TRUE(save_game.GetUserList()->UserExists(user2_id));
+	}
+}
+
+TEST_F(SaveGameTest, State) {
+	SaveGame save_game;
+	save_game.Load(save_file_path);
+
+	EXPECT_EQ(save_game.GetUserList()->GetUsers()->size(), 1);
+}
+
+TEST(UserList_class_test, Constructor) {
+	UserList user_list;
+
+	EXPECT_EQ(user_list.GetUsers()->size(), 0);
+}
+
+TEST(UserList_class_test, AddUser) {
+	UserList user_list;
+	auto users = user_list.GetUsers();
+	auto user = proto::User();
+	user.set_id("user-1");
+
+	user_list.AddUser(user);
+	EXPECT_EQ(users->size(), 1);
+}
+
+TEST(UserList_class_test, UserExists) {
+	UserList user_list;
+	auto users = user_list.GetUsers();
+	uid user_id = "user-1";
+	auto user = proto::User();
+	user.set_id(user_id);
+
+	user_list.AddUser(user);
+	EXPECT_TRUE(user_list.UserExists(user_id));
+
+	uid invalid_user_id = "user-2";
+	EXPECT_FALSE(user_list.UserExists(invalid_user_id));
+}
+
+TEST(UserList_class_test, RemoveUser) {
+	UserList user_list;
+	auto users = user_list.GetUsers();
+	auto user = proto::User();
+	uid user_id = "user-1";
+	user.set_id(user_id);
+
+	user_list.AddUser(user);
+	EXPECT_EQ(users->size(), 1);
+
+	uid invalid_user_id = "user-2";
+	user_list.RemoveUser(invalid_user_id);
+	EXPECT_EQ(users->size(), 1);
+
+	user_list.RemoveUser(user_id);
+	EXPECT_EQ(users->size(), 0);
+}
+
+TEST(UserList_class_test, UpdateUser) {
+	UserList user_list;
+	uid user_id = "user-1";
+	auto users = user_list.GetUsers();
+	{
+		auto user = proto::User();
+		user.set_id(user_id);
+		user_list.AddUser(user);
+	}
+
+	auto user = user_list.GetUser(user_id);
+	uid user_id2 = "user-2";
+	user->set_id(user_id2);
+
+	EXPECT_FALSE(user_list.UserExists(user_id));
+	EXPECT_TRUE(user_list.UserExists(user_id2));
+}


### PR DESCRIPTION
Fixed issue were in tests FilePath::PATH_SEPARATOR was not being set correctly.

Fixed tests in general.

Entities are no longer loaded on the client and therefore the world will appear empty. The assets that contains the correct set of entities cannot be transmitted over the wire and therefore when you connect the world will remain empty.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The purpose of the SaveGame is to provide an interface into saving/loading the game's state to a file. Currently loaded is the entities within the world as well as the user's state (position) associated with their user_id and username.

When the world entity list is loaded it emits an EntityCreated event for each loaded entity. However it has no way to get the list of entities during save.

If a user is retrieved from the SaveGame::UserList and updated, then when saving that state is saved to disk.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New tests have been added to demonstrate usage and ensure expectations are met from the feature.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
