### PR TITLE
Add some debugging for Lua script errors

### DIFF
--- a/common/components/lua-script.cpp
+++ b/common/components/lua-script.cpp
@@ -23,7 +23,16 @@ void LuaScript::ReloadScript() {
 		return;
 	}
 	if (!this->script_name.empty()) {
-		this->global_state->script(this->script->GetScript(), environment);
+		this->global_state->safe_script(
+				this->script->GetScript(),
+				environment,
+				[](lua_State*, sol::protected_function_result pfr) {
+					sol::error err = pfr;
+					spdlog::get("console_log")->warn("Script error: {}", err.what());
+					// if we don't throw anything, then we have to return this
+					return pfr;
+				},
+				this->script_name);
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds error handlers to scripts, this allows Lua tracebacks
Also default loads more of the embedded standard library (such as the oh-so-useful `string` lib)
The `print` now correctly applies `tostring` to it's arguments

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When something goes wrong with a Lua script, no diagnostics were shown, this adds some.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```lua
print("test", 1, true, nil)  -- test 1 true nil
print(window_width)  -- nil
require("config")
print(window_width)  -- 1024
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
