### PR TITLE
Workaround an asio bug on OSX, async connect and clean up warnings

### DIFF
--- a/client/game.hpp
+++ b/client/game.hpp
@@ -64,6 +64,7 @@ private:
 
 	ServerStats stats;
 	Simulation simulation;
+	OS& os;
 	ClientGameStateQueue game_state_queue;
 	ServerConnection server_connection;
 	RenderSystem rs;
@@ -71,7 +72,6 @@ private:
 	VComputerSystem& vcs;
 	SoundSystem ss;
 	LuaSystem lua_sys;
-	OS& os;
 
 	double delta_accumulator = 0.0; // Accumulated deltas since the last update was sent.
 	state_id_t command_id = 0;

--- a/client/server-connection.cpp
+++ b/client/server-connection.cpp
@@ -13,6 +13,10 @@ const std::string_view LOCAL_HOST = "127.0.0.1";
 std::shared_ptr<spdlog::logger> ServerConnection::_log;
 std::mutex ServerConnection::recent_ping_mutex;
 
+asio::io_context ServerConnection::io_context;
+asio::any_io_executor ServerConnection::io_work;
+std::mutex ServerConnection::write_msg_mutex;
+
 ServerConnection::ServerConnection(ServerStats& s) : socket(io_context), stats(s) {
 	_log = spdlog::get("console_log");
 	this->current_read_msg = MessagePool::get();
@@ -34,7 +38,7 @@ ServerConnection::ServerConnection(ServerStats& s) : socket(io_context), stats(s
 		data->entity_id = entity_id;
 		EventSystem<EntityDestroyed>::Get()->Emit(data);
 	});
-	RegisterMessageHandler(MessageType::ENTITY_CREATE, [this](MessageIn& message) {
+	RegisterMessageHandler(MessageType::ENTITY_CREATE, [](MessageIn& message) {
 		std::shared_ptr<EntityCreated> data = std::make_shared<EntityCreated>();
 		data->entity.ParseFromZeroCopyStream(&message);
 		data->entity_id = data->entity.id();
@@ -46,33 +50,42 @@ bool ServerConnection::Connect(std::string_view ip) {
 	Disconnect();
 	tcp::resolver resolver(this->io_context);
 	tcp::resolver::query query(std::string(ip).data(), std::string(SERVER_PORT).data());
-	asio::error_code error = asio::error::host_not_found;
-	tcp::resolver::results_type endpoints = resolver.resolve(query);
+	tcp::resolver::results_type query_results;
 	try {
-		for (auto& point : endpoints) {
-			this->socket.close();
-			this->socket.connect(point, error);
-			if (!error) {
-				break;
-			}
-		}
-		if (error) {
-			this->socket.close();
-			throw asio::system_error(error);
-		}
+		query_results = resolver.resolve(query);
 	}
 	catch (std::exception& e) {
-		_log->error("Connect: {}", e.what());
+		_log->error("Resolver failed: {}", e.what());
 		return false;
 	}
-
-	asio::ip::tcp::no_delay option(true);
-	this->socket.set_option(option);
-
-	if (this->onConnect) {
-		this->onConnect();
+	tcp::endpoint server_endpoint;
+	for (auto& query_result : query_results) {
+		auto query_point = query_result.endpoint(); // convert it to an endpoint
+		auto query_address = query_point.address();
+		if (query_address.is_v4()) { // only accept v4 for now, TODO: make sure IPv6 works too
+			server_endpoint = query_point;
+		}
+		_log->info("Resolved [{} {}]", query_address.to_string(), query_point.port());
 	}
-	read_header();
+	if (server_endpoint.address().is_unspecified()) {
+		_log->error("No valid endpoints or unsupported protocol");
+		return false;
+	}
+	this->socket.close();
+	this->socket.async_connect(server_endpoint, [this](const asio::error_code& error) {
+		if (error) {
+			this->socket.close();
+			_log->error("Connection error: {}", error.message());
+			return;
+		}
+		asio::ip::tcp::no_delay option(true);
+		this->socket.set_option(option);
+
+		if (this->onConnect) {
+			this->onConnect();
+		}
+		read_header();
+	});
 
 	return true;
 }
@@ -84,6 +97,8 @@ void ServerConnection::Disconnect() {
 }
 
 void ServerConnection::Stop() {
+	io_work = asio::any_io_executor();
+	this->socket.close();
 	this->run_dispatch = false;
 	this->run_sync = false;
 }
@@ -238,9 +253,13 @@ void ServerConnection::do_write() {
 
 void ServerConnection::StartDispatch() {
 	this->run_dispatch = true;
+	// tell the context it has stuff to do, fixes an issue on OSX
+	io_work = asio::require(io_context.get_executor(), asio::execution::outstanding_work.tracked);
+	_log->info("StartDispatch() is starting");
 	while (this->run_dispatch) {
 		try {
-			this->io_context.run();
+			// apparently run() causes trouble here for some reason
+			this->io_context.poll();
 		}
 		catch (std::exception e) {
 			_log->error("ServerConnection asio exception: {}", e.what());

--- a/client/server-connection.hpp
+++ b/client/server-connection.hpp
@@ -98,7 +98,9 @@ private:
 	static std::shared_ptr<spdlog::logger> _log;
 
 	// ASIO variables
-	asio::io_context io_context;
+	// we are only ever going to have one io_context
+	static asio::io_context io_context;
+	static asio::any_io_executor io_work;
 	asio::ip::tcp::socket socket;
 
 	// Async dispatch and sync loop variables
@@ -108,7 +110,7 @@ private:
 	std::atomic<bool> run_dispatch;
 	std::atomic<bool> run_sync;
 	std::deque<MessagePool::ptr_type> write_msg_queue;
-	std::mutex write_msg_mutex;
+	static std::mutex write_msg_mutex;
 
 	// Ping variables
 	std::chrono::high_resolution_clock::time_point sync_start, recv_time;

--- a/common/events.hpp
+++ b/common/events.hpp
@@ -101,7 +101,7 @@ struct ChatCommandEvent {
 	void Out(proto::ChatCommand chat_command) {
 		chat_command.set_command(this->command);
 		auto arguments = chat_command.mutable_arguments();
-		for (const std::string argument : this->args) {
+		for (const std::string& argument : this->args) {
 			arguments->Add(std::string(argument));
 		}
 	}
@@ -109,10 +109,10 @@ struct ChatCommandEvent {
 		proto::ChatCommand chat_command;
 		chat_command.set_command(this->command);
 		auto arguments = chat_command.mutable_arguments();
-		for (const std::string argument : this->args) {
+		for (const std::string& argument : this->args) {
 			arguments->Add(std::string(argument));
 		}
-		return std::move(chat_command);
+		return chat_command;
 	}
 };
 } // namespace tec

--- a/common/net-message.hpp
+++ b/common/net-message.hpp
@@ -214,7 +214,7 @@ public:
 		std::string body;
 		body.reserve(GetSize());
 		ReadString(body);
-		return std::move(body);
+		return body;
 	}
 
 	void SetMessageType(MessageType value) { this->message_type = value; }

--- a/server/client-connection.cpp
+++ b/server/client-connection.cpp
@@ -152,6 +152,7 @@ void ClientConnection::read_body() {
 				MessagePool::ptr_type last_read_msg = current_read_msg;
 				current_read_msg = MessagePool::get();
 				uint32_t current_msg_id = last_read_msg->GetMessageID();
+				uint32_t current_msg_seq = last_read_msg->GetSequence();
 				auto message_iter = read_messages.find(current_msg_id);
 
 				if (last_read_msg->GetMessageType() == MessageType::MULTI_PART) {
@@ -168,7 +169,6 @@ void ClientConnection::read_body() {
 					// a single use MessageIn object for single fragment messages
 					MessageIn short_message_in;
 					MessageIn* message_in; // pointer to the message we use
-					uint32_t current_msg_seq = last_read_msg->GetSequence();
 					if (message_iter == read_messages.cend()) {
 						message_in = &short_message_in;
 					}
@@ -247,7 +247,8 @@ void ClientConnection::process_message(MessageIn& msg) {
 	case MessageType::CLIENT_JOIN:
 	case MessageType::CLIENT_ID:
 	case MessageType::CLIENT_LEAVE:
-	case MessageType::GAME_STATE_UPDATE: break;
+	case MessageType::GAME_STATE_UPDATE:
+	default: break;
 	}
 }
 
@@ -308,7 +309,7 @@ MessageOut ClientConnection::PrepareGameStateUpdateMessage(state_id_t current_st
 	}
 	MessageOut update_message(MessageType::GAME_STATE_UPDATE);
 	gsu_msg.SerializeToZeroCopyStream(&update_message);
-	return std::move(update_message);
+	return update_message;
 }
 } // namespace networking
 } // namespace tec

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -233,6 +233,7 @@ void Server::AcceptHandler() {
 		}
 		client->StartRead();
 
+		_log->debug("Server::AcceptHandler complete");
 		AcceptHandler();
 	});
 }

--- a/tests/net-message_test.cpp
+++ b/tests/net-message_test.cpp
@@ -8,11 +8,9 @@
 namespace tec {
 namespace networking {
 
-// clang-format off
-// Warning: these are picky about whitespace, the s has to go right on the end to make a literal
 #define _STRINGIFY(a) #a
-#define CASE_LABEL(t) case t: return _STRINGIFY(t)s
-// clang-format on
+#define CASE_LABEL(t) case t: return _STRINGIFY(t)
+
 std::string GetNamedMessageType(MessageType mt) {
 	using namespace std::string_literals;
 	switch (mt) {
@@ -372,7 +370,8 @@ TEST(MessageIn, ToOut) {
 	EXPECT_TRUE(msgin.DecodeMessages());
 	MessageOut msgclone = msgin.ToOut();
 	EXPECT_EQ(msgout.ByteCount(), msgclone.ByteCount());
-	MessageListContentEqual(msgs, msgclone.GetMessages());
+	auto msgs_clone = msgclone.GetMessages();
+	MessageListContentEqual(msgs, msgs_clone);
 }
 
 } // namespace networking

--- a/tests/net-message_test.cpp
+++ b/tests/net-message_test.cpp
@@ -9,7 +9,8 @@ namespace tec {
 namespace networking {
 
 #define _STRINGIFY(a) #a
-#define CASE_LABEL(t) case t: return _STRINGIFY(t)
+#define CASE_LABEL(t) \
+	case t: return _STRINGIFY(t)
 
 std::string GetNamedMessageType(MessageType mt) {
 	using namespace std::string_literals;
@@ -121,7 +122,9 @@ TEST(Message, initial) {
 	// sanity check
 	int leaked_objects = 0;
 	for (int i = 0; i < 1000; i++) {
-		ASSERT_NE(*make_test_unique<init_test_class>(&leaked_objects), *make_test_unique<init_test_class>(&leaked_objects));
+		ASSERT_NE(
+				*make_test_unique<init_test_class>(&leaked_objects),
+				*make_test_unique<init_test_class>(&leaked_objects));
 		ASSERT_EQ(leaked_objects, 0);
 	}
 	// do the actual test on Message


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The asio fix is to set work tracking and use `poll()` instead of `run()`
Removed some std::move that the compiler flagged for RVO
Made the client's Connect asynchronous, it will also show the addresses it resolved.
Made client's asio variables static, since there can only be one.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
On OS X, asio was not calling handlers in the client code, result was a brick.
Also got rid of a bunch of warnings, they were bothering me.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run the tests, server, and client on Mac OS X

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
