### PR TITLE
Fix workflow not building release builds

### DIFF
--- a/.github/workflows/tec.yml
+++ b/.github/workflows/tec.yml
@@ -69,6 +69,7 @@ jobs:
       with:
         cmakeListsOrSettingsJson: 'CMakeListsTxtBasic'
         cmakeListsTxtPath: '${{ github.workspace }}/CMakeLists.txt'
+        cmakeBuildType: 'Release'
         useVcpkgToolchainFile: true
         buildWithCMake: true
         buildDirectory: '${{ github.workspace }}/build'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The current build pipeline only builds debug versions, which on windows is causing it to look for the Visual C++ **Debug** runtime which is not available as a redistributable.

We should probably be releasing **Release** builds anyways.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
