### PR TITLE
Redo the Filesystem API

### DIFF
--- a/client/game.cpp
+++ b/client/game.cpp
@@ -33,7 +33,7 @@ Game::Game(OS& _os, std::string config_file_name) :
 		stats(), os(_os), game_state_queue(this->stats), server_connection(this->stats),
 		ps(this->simulation.GetPhysicsSystem()), vcs(this->simulation.GetVComputerSystem()),
 		sound_thread([this]() { ss.Update(); }) {
-	this->config_script = this->lua_sys.LoadFile(FilePath::GetAssetPath(config_file_name));
+	this->config_script = this->lua_sys.LoadFile(Path::GetAssetPath(config_file_name));
 	this->server_connection.RegisterMessageHandler(MessageType::CLIENT_ID, [this](networking::MessageIn&) {
 		auto client_id = server_connection.GetClientID();
 		game_state_queue.SetClientID(client_id);

--- a/client/graphics/animation.cpp
+++ b/client/graphics/animation.cpp
@@ -2,6 +2,7 @@
 
 #include <functional>
 
+#include "file-factories.hpp"
 #include "resources/md5anim.hpp"
 #include "resources/md5mesh.hpp"
 
@@ -72,7 +73,6 @@ void Animation::Out(proto::Component* target) {
 	comp->set_animation_name(this->animation_name);
 }
 
-extern std::unordered_map<std::string, std::function<void(std::string)>> file_factories;
 void Animation::In(const proto::Component& source) {
 	const proto::Animation& comp = source.animation();
 	if (!comp.has_animation_name()) {
@@ -83,21 +83,9 @@ void Animation::In(const proto::Component& source) {
 	}
 	this->looping = comp.loop();
 	this->animation_name = comp.animation_name();
-	if (!AnimationMap::Has(this->animation_name)) {
-		std::string ext = this->animation_name.substr(this->animation_name.find_last_of(".") + 1);
-		if (file_factories.find(ext) != file_factories.end()) {
-			file_factories[ext](this->animation_name);
-		}
-	}
 	const auto mesh_name = comp.mesh_name();
-	if (!MeshMap::Has(mesh_name)) {
-		std::string ext = mesh_name.substr(mesh_name.find_last_of(".") + 1);
-		if (file_factories.find(ext) != file_factories.end()) {
-			file_factories[ext](mesh_name);
-		}
-	}
-	const auto animation{AnimationMap::Get(this->animation_name)};
-	animation->CheckMesh(std::static_pointer_cast<MD5Mesh>(MeshMap::Get(mesh_name)));
+	const auto animation{GetResource<MD5Anim>(this->animation_name)};
+	animation->CheckMesh(std::static_pointer_cast<MD5Mesh>(GetResource<MeshFile>(mesh_name)));
 	this->SetAnimationFile(animation);
 }
 } // namespace tec

--- a/client/graphics/renderable.cpp
+++ b/client/graphics/renderable.cpp
@@ -1,5 +1,6 @@
 #include "renderable.hpp"
 
+#include "file-factories.hpp"
 #include "resources/mesh.hpp"
 #include "shader.hpp"
 #include "vertex-buffer-object.hpp"
@@ -18,19 +19,11 @@ void Renderable::Out(proto::Component* target) {
 	this->local_orientation.Out(comp->mutable_orientation());
 }
 
-extern std::unordered_map<std::string, std::function<void(std::string)>> file_factories;
-
 void Renderable::In(const proto::Component& source) {
 	const proto::Renderable& comp = source.renderable();
 	if (comp.has_mesh_name()) {
 		this->mesh_name = comp.mesh_name();
-		if (!MeshMap::Has(this->mesh_name)) {
-			std::string ext = this->mesh_name.substr(this->mesh_name.find_last_of(".") + 1);
-			if (file_factories.find(ext) != file_factories.end()) {
-				file_factories[ext](this->mesh_name);
-			}
-		}
-		this->mesh = MeshMap::Get(this->mesh_name);
+		this->mesh = GetResource<MeshFile>(this->mesh_name);
 	}
 	if (comp.has_shader_name()) {
 		this->shader_name = comp.shader_name();

--- a/client/graphics/shader.cpp
+++ b/client/graphics/shader.cpp
@@ -41,7 +41,7 @@ void Shader::DeleteProgram() {
 	this->shaders.clear();
 }
 
-void Shader::LoadFromFile(const gfx::ShaderType type, const tec::FilePath& fname) {
+void Shader::LoadFromFile(const gfx::ShaderType type, const tec::Path& fname) {
 	auto _log = spdlog::get("console_log");
 	if (!fname.isValidPath()) {
 		_log->error("[Shader] Error loading shader: {} Invalid path: {}", fname.FileName(), fname.toString());
@@ -268,7 +268,7 @@ GLint Shader::GetAttributeLocation(const std::string name) {
 }
 
 std::shared_ptr<Shader>
-Shader::CreateFromFile(const std::string name, std::list<std::pair<gfx::ShaderType, FilePath>> filenames) {
+Shader::CreateFromFile(const std::string name, std::list<std::pair<gfx::ShaderType, Path>> filenames) {
 	auto s = std::make_shared<Shader>();
 	for (auto pair : filenames) {
 		s->LoadFromFile(pair.first, pair.second);
@@ -302,8 +302,8 @@ void Shader::LoadFromProto(const gfx::ShaderSource& source, gfx::ShaderType type
 		return;
 	}
 	switch (source.source_case()) {
-	case gfx::ShaderSource::kFile: LoadFromFile(type, FilePath::GetAssetPath("shaders") / source.file()); break;
-	case gfx::ShaderSource::kAbsFile: LoadFromFile(type, FilePath(source.abs_file())); break;
+	case gfx::ShaderSource::kFile: LoadFromFile(type, Path::GetAssetPath("shaders") / source.file()); break;
+	case gfx::ShaderSource::kAbsFile: LoadFromFile(type, Path(source.abs_file())); break;
 	case gfx::ShaderSource::kRaw: LoadFromString(type, source.raw(), "proto-" + std::to_string(type)); break;
 	case gfx::ShaderSource::kByName:
 		spdlog::get("console_log")->error("[Shader] LoadFromProto by_name not implemented");
@@ -352,10 +352,8 @@ void Shader::IncludeFromDef(const gfx::ShaderInclude& shader_inc) {
 	auto source = shader_inc.source();
 	std::string include_string;
 	switch (source.source_case()) {
-	case gfx::ShaderSource::kFile:
-		include_string = LoadAsString(FilePath::GetAssetPath("shaders") / source.file());
-		break;
-	case gfx::ShaderSource::kAbsFile: include_string = LoadAsString(FilePath(source.abs_file())); break;
+	case gfx::ShaderSource::kFile: include_string = LoadAsString(Path::GetAssetPath("shaders") / source.file()); break;
+	case gfx::ShaderSource::kAbsFile: include_string = LoadAsString(Path(source.abs_file())); break;
 	case gfx::ShaderSource::kRaw: include_string = source.raw(); break;
 	case gfx::ShaderSource::kByName: _log->error("[Shader] IncludeFromDef by_name not implemented"); break;
 	case gfx::ShaderSource::SOURCE_NOT_SET:

--- a/client/graphics/shader.cpp
+++ b/client/graphics/shader.cpp
@@ -43,20 +43,20 @@ void Shader::DeleteProgram() {
 
 void Shader::LoadFromFile(const gfx::ShaderType type, const tec::Path& fname) {
 	auto _log = spdlog::get("console_log");
-	if (!fname.isValidPath()) {
-		_log->error("[Shader] Error loading shader: {} Invalid path: {}", fname.FileName(), fname.toString());
+	if (!fname) {
+		_log->error("[Shader] Load Error: Invalid path: {}", fname.toString());
 		return;
 	}
 	if (!fname.FileExists()) {
-		_log->error("[Shader] Error loading shader: {} File don't exists. Check assets folder", fname.FileName());
+		_log->error("[Shader] Load Error: File does not exist, Check assets folder: {}", fname.toString());
 		return;
 	}
-	std::ifstream fp(fname.GetNativePath(), std::ios_base::in);
-	if (!fp.is_open()) {
-		_log->error("[Shader] Error loading shader: {} File don't exists. Check open file.", fname.FileName());
+	auto fp = fname.OpenStream(); // TODO GetFileContent API?
+	if (!fp->is_open()) {
+		_log->error("[Shader] Load Error: Can not open file: {}", fname);
 		return;
 	}
-	std::string buffer(std::istreambuf_iterator<char>(fp), (std::istreambuf_iterator<char>()));
+	std::string buffer(std::istreambuf_iterator<char>(*fp), (std::istreambuf_iterator<char>()));
 	LoadFromString(type, buffer, fname.FileName());
 }
 

--- a/client/graphics/shader.hpp
+++ b/client/graphics/shader.hpp
@@ -61,13 +61,13 @@ public:
 	* Filenames should be something like:
 	* \code{.cpp}:
 	* auto shader_files = std::list < std::pair<Shader::ShaderType, std::string> > {
-	*	std::make_pair(Shader::VERTEX, FilePath("basic.vert")), std::make_pair(Shader::FRAGMENT,
-	*FilePath("./basic.frag")),
+	*	std::make_pair(Shader::VERTEX, Path("basic.vert")), std::make_pair(Shader::FRAGMENT,
+	*Path("./basic.frag")),
 	* };
 	* \return is a shared_ptr to the created Shader.
 	*/
 	static std::shared_ptr<Shader>
-	CreateFromFile(const std::string name, std::list<std::pair<gfx::ShaderType, tec::FilePath>> filenames);
+	CreateFromFile(const std::string name, std::list<std::pair<gfx::ShaderType, tec::Path>> filenames);
 
 	/**
 	* \brief Creates a Shader the provide source code stores it in ShaderMap under name.
@@ -101,11 +101,11 @@ public:
 	/**
 	* \brief Loads the specified ShaderType from file filename.
 	* \param const ShaderType type The type of shader that is being loaded i.e. VERTEX, FRAGMENT, etc.
-	* \param const FilePath filename The filename of the source file to load
+	* \param const Path filename The filename of the source file to load
 	* (relative to assets folder)
 	* \return void
 	*/
-	void LoadFromFile(const gfx::ShaderType type, const tec::FilePath& filename);
+	void LoadFromFile(const gfx::ShaderType type, const tec::Path& filename);
 
 	/**
 	* \brief Loads the specified ShaderType from the source string provided..

--- a/client/imgui-system.cpp
+++ b/client/imgui-system.cpp
@@ -30,8 +30,8 @@ IMGUISystem::IMGUISystem(GLFWwindow* _window) {
 	ImGui::CreateContext();
 	IMGUISystem::window = _window;
 	auto& io = ImGui::GetIO();
-	inifilename = (FilePath::GetUserSettingsPath() / "imgui.ini").toString();
-	logfilename = (FilePath::GetUserCachePath() / "imgui_log.txt").toString();
+	inifilename = (Path::GetUserSettingsPath() / "imgui.ini").toString();
+	logfilename = (Path::GetUserCachePath() / "imgui_log.txt").toString();
 	io.IniFilename = inifilename.c_str();
 #if defined(DEBUG) || defined(_DEBUG)
 	io.LogFilename = logfilename.c_str();

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -91,7 +91,7 @@ int main(int argc, char* argv[]) {
 
 	auto log = InitializeLogger(ParseLogLevel(argc, argv), console);
 
-	log->info(std::string("Asset path: ") + tec::FilePath::GetAssetsBasePath().toString());
+	log->info(std::string("Asset path: ") + tec::Path::GetAssetsBasePath().toString());
 
 	tec::Game game(os);
 

--- a/client/render-system.cpp
+++ b/client/render-system.cpp
@@ -99,7 +99,7 @@ void RenderSystem::Startup() {
 	ErrorCheck("Something went wrong when creating the context", __LINE__);
 
 	tec::gfx::RenderConfig render_config;
-	auto core_fname = FilePath::GetAssetPath("shaders/core.json");
+	auto core_fname = Path::GetAssetPath("shaders/core.json");
 	auto core_json = LoadAsString(core_fname);
 	auto status = google::protobuf::util::JsonStringToMessage(core_json, &render_config);
 	if (!status.ok()) {
@@ -148,14 +148,14 @@ void RenderSystem::Startup() {
 	// Reversed Z buffering for improved precision (maybe)
 	glClearDepth(0.0f);
 	glDepthFunc(GL_GREATER);
-	std::shared_ptr<OBJ> sphere = OBJ::Create(FilePath::GetAssetPath("/sphere/sphere.obj"));
+	std::shared_ptr<OBJ> sphere = OBJ::Create(Path::GetAssetPath("/sphere/sphere.obj"));
 	if (!sphere) {
 		_log->debug("[RenderSystem] Error loading sphere.obj.");
 	}
 	else {
 		this->sphere_vbo.Load(sphere);
 	}
-	std::shared_ptr<OBJ> quad = OBJ::Create(FilePath::GetAssetPath("/quad/quad.obj"));
+	std::shared_ptr<OBJ> quad = OBJ::Create(Path::GetAssetPath("/quad/quad.obj"));
 	if (!quad) {
 		_log->debug("[RenderSystem] Error loading quad.obj.");
 	}

--- a/client/resources/md5anim.cpp
+++ b/client/resources/md5anim.cpp
@@ -22,9 +22,9 @@ namespace tec {
 */
 extern std::string CleanString(std::string str);
 
-std::shared_ptr<MD5Anim> MD5Anim::Create(const FilePath& fname) {
+std::shared_ptr<MD5Anim> MD5Anim::Create(const Path& fname) {
 	auto anim = std::make_shared<MD5Anim>();
-	anim->SetName(fname.SubpathFrom("assets").toGenericString());
+	anim->SetName(fname.Subpath(1).toString());
 	anim->SetFileName(fname);
 
 	if (anim->Parse()) {
@@ -47,15 +47,15 @@ bool MD5Anim::Parse() {
 		return false;
 	}
 
-	std::ifstream f(this->path.GetNativePath(), std::ios::in);
-	if (!f.is_open()) {
+	auto f = this->path.OpenStream();
+	if (!f->is_open()) {
 		_log->error("[MD5Anim] Error opening file {}", path.toString());
 		return false;
 	}
 
 	std::string line;
 	unsigned int num_components = 0;
-	while (std::getline(f, line)) {
+	while (std::getline(*f, line)) {
 		std::stringstream ss(line);
 		std::string identifier;
 
@@ -85,7 +85,7 @@ bool MD5Anim::Parse() {
 			ss >> num_components;
 		}
 		else if (identifier == "hierarchy") {
-			while (std::getline(f, line)) {
+			while (std::getline(*f, line)) {
 				if (line.find("\"") != std::string::npos) {
 					ss.str(CleanString(line));
 					Joint bone;
@@ -100,7 +100,7 @@ bool MD5Anim::Parse() {
 			}
 		}
 		else if (identifier == "bounds") {
-			while (std::getline(f, line)) {
+			while (std::getline(*f, line)) {
 				if ((line.find("(") != std::string::npos) && (line.find(")") != std::string::npos)) {
 					ss.str(CleanString(line));
 					BoundingBox bbox;
@@ -117,7 +117,7 @@ bool MD5Anim::Parse() {
 		}
 		else if (identifier == "baseframe") {
 			std::size_t index = 0;
-			while (std::getline(f, line)) {
+			while (std::getline(*f, line)) {
 				if ((line.find("(") != std::string::npos) && (line.find(")") != std::string::npos)) {
 					ss.str(CleanString(line));
 					auto& joint = this->joints[index];
@@ -140,7 +140,7 @@ bool MD5Anim::Parse() {
 			Frame frame;
 			ss >> frame.index;
 			unsigned int number = 0;
-			while (std::getline(f, line)) {
+			while (std::getline(*f, line)) {
 				ss.clear();
 				ss.str(line);
 				// Check if the line contained the closing brace. This is done after parsing

--- a/client/resources/md5anim.cpp
+++ b/client/resources/md5anim.cpp
@@ -41,7 +41,7 @@ std::shared_ptr<MD5Anim> MD5Anim::Create(const Path& fname) {
 
 bool MD5Anim::Parse() {
 	auto _log = spdlog::get("console_log");
-	if (!this->path.isValidPath() || !this->path.FileExists()) {
+	if (!this->path || !this->path.FileExists()) {
 		_log->error("[MD5Anim] Can't open the file {}. Invalid path or missing file.", path.toString());
 		// Can't open the file!
 		return false;

--- a/client/resources/md5anim.hpp
+++ b/client/resources/md5anim.hpp
@@ -61,10 +61,10 @@ public:
 	* \brief Returns a resource with the specified name.
 	*
 	* The only used initialization property is "filename".
-	* \param[in] const FilePath& fname The filename of the MD5Anim resource
+	* \param[in] const Path& fname The filename of the MD5Anim resource
 	* \return std::shared_ptr<MD5Anim> The create MD5Anim resource.
 	*/
-	static std::shared_ptr<MD5Anim> Create(const FilePath& fname);
+	static std::shared_ptr<MD5Anim> Create(const Path& fname);
 
 	/**
 	* \brief Loads the MD5Anim file from disk and parses it.
@@ -80,9 +80,9 @@ public:
 	* \param[in] const std::string& fname The mesh filename.
 	* \return bool True if initialization finished with no errors.
 	*/
-	void SetFileName(const FilePath& fname) { this->path = fname; }
+	void SetFileName(const Path& fname) { this->path = fname; }
 
-	FilePath GetFileName() { return this->path; }
+	Path GetFileName() { return this->path; }
 
 	const std::string GetName() const { return this->name; }
 
@@ -133,7 +133,7 @@ public:
 			float delta);
 
 private:
-	FilePath path; // Relative filename
+	Path path; // Relative filename
 	std::string name;
 	std::vector<BoundingBox> bounds; // Bound box sizes for each join.
 	std::vector<Frame> frames;

--- a/client/resources/md5mesh.cpp
+++ b/client/resources/md5mesh.cpp
@@ -132,7 +132,7 @@ std::shared_ptr<MD5Mesh> MD5Mesh::Create(const Path& fname) {
 
 bool MD5Mesh::Parse() {
 	auto _log = spdlog::get("console_log");
-	if (!this->path.isValidPath() || !this->path.FileExists()) {
+	if (!this->path || !this->path.FileExists()) {
 		_log->error("[MD5Mesh] Can't open the file {}. Invalid path or missing file.", path.toString());
 		// Can't open the file!
 		return false;

--- a/client/resources/md5mesh.cpp
+++ b/client/resources/md5mesh.cpp
@@ -113,10 +113,10 @@ MD5Mesh::Weight ParsesWeight(std::stringstream& ss) {
 	return w;
 }
 
-std::shared_ptr<MD5Mesh> MD5Mesh::Create(const FilePath& fname) {
+std::shared_ptr<MD5Mesh> MD5Mesh::Create(const Path& fname) {
 	auto mesh = std::make_shared<MD5Mesh>();
 	mesh->SetFileName(fname);
-	mesh->SetName(fname.SubpathFrom("assets").toGenericString());
+	mesh->SetName(fname.Subpath(1).toString());
 
 	if (mesh->Parse()) {
 		mesh->CalculateVertexPositions();
@@ -139,15 +139,15 @@ bool MD5Mesh::Parse() {
 	}
 	auto base_path = this->path.BasePath();
 
-	std::ifstream f(this->path.GetNativePath(), std::ios::in);
-	if (!f.is_open()) {
+	auto f = this->path.OpenStream();
+	if (!f->is_open()) {
 		_log->error("[MD5Mesh] Error opening file {}", path.toString());
 		return false;
 	}
 	_log->debug("[MD5Mesh] Parsing file {}", path.toString());
 
 	std::string line;
-	while (std::getline(f, line)) {
+	while (std::getline(*f, line)) {
 		std::stringstream ss(line);
 		std::string identifier;
 
@@ -171,7 +171,7 @@ bool MD5Mesh::Parse() {
 			this->meshes_internal.reserve(nmeshes);
 		}
 		else if (identifier == "joints") {
-			while (std::getline(f, line)) {
+			while (std::getline(*f, line)) {
 				if (line.find("\"") != std::string::npos) {
 					ss.str(CleanString(line));
 					Joint joint(ParseJoint(ss));
@@ -187,7 +187,7 @@ bool MD5Mesh::Parse() {
 		else if (identifier == "mesh") {
 			InternalMesh mesh;
 			int embedded_list = 0;
-			while (std::getline(f, line)) {
+			while (std::getline(*f, line)) {
 				std::string line2 = CleanString(line);
 				ss.str(line2);
 				ss.clear();

--- a/client/resources/md5mesh.hpp
+++ b/client/resources/md5mesh.hpp
@@ -59,10 +59,10 @@ public:
 	* \brief Returns a resource with the specified name.
 	*
 	* The only used initialization property is "filename".
-	* \param[in] const FilePath& fname The filename of the MD5Mesh resource
+	* \param[in] const Path& fname The filename of the MD5Mesh resource
 	* \return std::shared_ptr<MD5Mesh> The created MD5Mesh resource.
 	*/
-	static std::shared_ptr<MD5Mesh> Create(const FilePath& fname);
+	static std::shared_ptr<MD5Mesh> Create(const Path& fname);
 
 	/**
 	* \brief Loads the MD5Mesh file from disk and parses it.
@@ -105,14 +105,14 @@ public:
 	* \param[in] const std::string& fname The mesh filename.
 	* \return bool True if initialization finished with no errors.
 	*/
-	void SetFileName(const FilePath& fname) { this->path = fname; }
+	void SetFileName(const Path& fname) { this->path = fname; }
 
 	// Used for MD5Anim::CheckMesh().
 	friend class MD5Anim;
 
 private:
 	std::vector<InternalMesh> meshes_internal;
-	FilePath path; // Path to MD5Mesh file
+	Path path; // Path to MD5Mesh file
 	std::vector<Joint> joints;
 };
 } // namespace tec

--- a/client/resources/obj.cpp
+++ b/client/resources/obj.cpp
@@ -23,7 +23,7 @@ extern std::string CleanString(std::string str);
 
 bool OBJ::ParseMTL(const Path& fname) {
 	auto _log = spdlog::get("console_log");
-	if (!fname.isValidPath() || !fname.FileExists()) {
+	if (!fname || !fname.FileExists()) {
 		_log->error("[OBJ] Can't open the file {}. Invalid path or missing file.", fname.toString());
 		// Can't open the file!
 		return false;
@@ -146,7 +146,7 @@ std::shared_ptr<OBJ> OBJ::Create(const Path& fname) {
 
 bool OBJ::Parse() {
 	auto _log = spdlog::get("console_log");
-	if (!this->path.isValidPath() || !this->path.FileExists()) {
+	if (!this->path || !this->path.FileExists()) {
 		_log->error("[OBJ] Can't open the file {}. Invalid path or missing file.", path.toString());
 		// Can't open the file!
 		return false;

--- a/client/resources/obj.hpp
+++ b/client/resources/obj.hpp
@@ -55,10 +55,10 @@ public:
 	* \brief Returns a resource with the specified name.
 	*
 	* The only used initialization property is "filename".
-	* \param[in] const FilePath& fname The filename of the OBJ resource
+	* \param[in] const Path& fname The filename of the OBJ resource
 	* \return std::shared_ptr<OBJ> The created OBJ resource.
 	*/
-	static std::shared_ptr<OBJ> Create(const FilePath& fname);
+	static std::shared_ptr<OBJ> Create(const Path& fname);
 
 	/**
 	* \brief Loads the OBJ file from disk and parses it.
@@ -72,7 +72,7 @@ public:
 	*
 	* \return bool If the material was valid and loaded correctly.
 	*/
-	bool ParseMTL(const FilePath& fname);
+	bool ParseMTL(const Path& fname);
 
 	/**
 	* \brief Calculates the final vertex positions based on the bind-pose skeleton.
@@ -90,11 +90,11 @@ public:
 	* \param[in] const std::string& fname The mesh filename.
 	* \return bool True if initialization finished with no errors.
 	*/
-	void SetFileName(const FilePath& fname) { this->path = fname; }
+	void SetFileName(const Path& fname) { this->path = fname; }
 
 private:
 	std::vector<std::shared_ptr<OBJGroup>> vertexGroups;
-	FilePath path; // Path to OBJ file
+	Path path; // Path to OBJ file
 	std::vector<glm::vec3> positions;
 	std::vector<glm::vec3> normals;
 	std::vector<glm::vec2> uvs;

--- a/client/resources/pixel-buffer.hpp
+++ b/client/resources/pixel-buffer.hpp
@@ -37,10 +37,10 @@ public:
 	/**
 	* \brief Returns a resource with the specified name.
 	*
-	* \param[in] const FilePath filename The filename of the image file to load.
+	* \param[in] const Path filename The filename of the image file to load.
 	* \return bool True if initialization finished with no errors.
 	*/
-	bool Load(const FilePath& filename, bool gamma_space = false);
+	bool Load(const Path& filename, bool gamma_space = false);
 
 	PixelBuffer(const PixelBuffer&) = delete;
 	PixelBuffer& operator=(const PixelBuffer&) = delete;
@@ -84,11 +84,11 @@ public:
 	* PixelBufferMap under name.  It will optionally load a texture file
 	* with the given filename.
 	* \param const std::string name The name to store the PixelBuffer under.
-	* \param const FilePath filename The optional filename of the image to load.
+	* \param const Path filename The optional filename of the image to load.
 	* \return std::shared_ptr<PixelBuffer> The created PixelBuffer.
 	*/
 	static std::shared_ptr<PixelBuffer>
-	Create(const std::string name, const FilePath& filename = FilePath(), bool gamma_space = false);
+	Create(const std::string name, const Path& filename = Path(), bool gamma_space = false);
 
 	bool IsDirty() const;
 	/** \brief Mark dirty */

--- a/client/resources/vorbis-stream.hpp
+++ b/client/resources/vorbis-stream.hpp
@@ -56,7 +56,7 @@ public:
 	* \param[in] const std::vector<Property>& properties The creation properties for the
 	* resource. \return std::shared_ptr<VorbisStream> The created VorbisStream resource.
 	*/
-	static std::shared_ptr<VorbisStream> Create(const FilePath& filename);
+	static std::shared_ptr<VorbisStream> Create(const Path& filename);
 
 	const std::string GetName() const { return this->name; }
 	void SetName(const std::string& _name) { this->name = _name; }

--- a/client/voxel-volume.cpp
+++ b/client/voxel-volume.cpp
@@ -14,10 +14,10 @@
 
 namespace tec {
 VoxelVolume::VoxelVolume(std::weak_ptr<MeshFile> mesh) : mesh(mesh) {
-	auto pixbuf = PixelBuffer::Create("metal_wall", FilePath::GetAssetPath("metal_wall.png"), true);
+	auto pixbuf = PixelBuffer::Create("metal_wall", Path::GetAssetPath("metal_wall.png"), true);
 	auto tex = std::make_shared<TextureObject>(pixbuf);
 	TextureMap::Set("metal_wall", tex);
-	pixbuf = PixelBuffer::Create("metal_wall_sp", FilePath::GetAssetPath("metal_wall_sp.png"));
+	pixbuf = PixelBuffer::Create("metal_wall_sp", Path::GetAssetPath("metal_wall_sp.png"));
 	tex = std::make_shared<TextureObject>(pixbuf);
 	TextureMap::Set("metal_wall_sp", tex);
 }

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -31,7 +31,9 @@ endforeach()
 set(trillek-common_LIBRARY "tec" CACHE STRING "Name of the library with code common to both the client and the server")
 
 set(trillek-common_SOURCES
+	${trillek-common_SOURCE_DIR}/file-factories.cpp
 	${trillek-common_SOURCE_DIR}/filesystem.cpp
+	${trillek-common_SOURCE_DIR}/filesystem_platform.cpp
 	${trillek-common_SOURCE_DIR}/lua-system.cpp
 	${trillek-common_SOURCE_DIR}/net-message.cpp
 	${trillek-common_SOURCE_DIR}/physics-system.cpp

--- a/common/file-factories.cpp
+++ b/common/file-factories.cpp
@@ -1,0 +1,19 @@
+
+#include "file-factories.hpp"
+#include <spdlog/spdlog.h>
+
+namespace tec {
+std::unordered_map<std::string, std::function<void(std::string)>> file_factories;
+
+void InvokeFileFactory(const std::string& file_name) {
+	std::string ext = Path(file_name).FileExtension();
+	auto factory = file_factories.find(ext);
+	if (factory != file_factories.end()) {
+		factory->second(file_name);
+	}
+	else {
+		spdlog::get("console_log")->error("[FileFactory] No handler for extension: {}", ext);
+		throw std::exception();
+	}
+}
+} // namespace tec

--- a/common/file-factories.hpp
+++ b/common/file-factories.hpp
@@ -4,18 +4,32 @@
 #include <unordered_map>
 
 #include "filesystem.hpp"
+#include "multiton.hpp"
 #include "tec-types.hpp"
 
 namespace tec {
-std::unordered_map<std::string, std::function<void(std::string)>> file_factories;
+extern std::unordered_map<std::string, std::function<void(std::string)>> file_factories;
+
+void InvokeFileFactory(const std::string& file_name);
+
+template <typename T> std::shared_ptr<T> GetResource(const std::string& res_name) {
+	if (res_name.empty()) {
+		return std::shared_ptr<T>();
+	}
+	if (!Multiton<std::string, std::shared_ptr<T>>::Has(res_name)) {
+		InvokeFileFactory(res_name);
+	}
+	return Multiton<std::string, std::shared_ptr<T>>::Get(res_name);
+}
+
 template <typename T> void AddFileFactory() {
 	file_factories[GetTypeEXT<T>()] = [](std::string fname) {
-		FilePath path(fname);
+		Path path(fname);
 		if (path.isAbsolutePath()) {
-			T::Create(fname);
+			T::Create(path);
 		}
 		else {
-			T::Create(FilePath::GetAssetPath(fname));
+			T::Create(Path::GetAssetPath(fname));
 		}
 	};
 }

--- a/common/filesystem_platform.cpp
+++ b/common/filesystem_platform.cpp
@@ -1,31 +1,41 @@
 #include "filesystem.hpp"
 
+#include <iostream>
+#include <sstream>
+
+#include <sys/stat.h>
+#include <sys/types.h>
+
 // Stuff to get OS libs for paths
 #if defined(__APPLE__)
 #include <CoreServices/CoreServices.h>
 #include <mach-o/dyld.h>
-#include <unistd.h>
+#endif
 
-#elif defined(__unix__)
+#if defined(__unix__) || defined(__APPLE__)
+#include <dirent.h>
+#include <fcntl.h>
 #include <limits.h>
+#include <string.h>
 #include <unistd.h>
 
 #elif defined(WIN32)
-#ifndef UNICODE
+#ifndef UNICODE // get wide character definitions for things
 #define UNICODE 1
 #endif
-#include <Shlobj.h>
+#include <Shlobj.h> // for SHGetKnownFolderPath
 #include <Windows.h>
-#include <comutil.h>
-#include <direct.h>
+#include <comutil.h> // CoTaskMemFree
+#include <direct.h> // Posix like functions
+// Windows.h does evil things with macros
 #undef max
 #undef min
-
 #pragma comment(lib, "comsuppw")
+
 #endif
 
 #ifndef PATH_MAX
-#define PATH_MAX 1024 // same with Mac OS X's syslimits.h
+#define PATH_MAX 1024 // fall back if undefinied, based on OS X <sys/syslimits.h>
 #endif
 
 #ifndef TEXT
@@ -34,137 +44,549 @@
 
 namespace tec {
 
+bool Path::DirExists() const {
+#if defined(WIN32)
+	auto npath = this->GetNativePath();
+	// Trailing slash is not allowed
+	if (npath.size() && npath.back() == L'\\') {
+		npath.pop_back();
+	}
+	DWORD fa = GetFileAttributesW(npath.c_str());
+	// is what we found actually a directory?
+	return (fa != INVALID_FILE_ATTRIBUTES) && (0 != (fa & FILE_ATTRIBUTE_DIRECTORY));
+#else
+	struct stat s;
+	auto npath = this->GetNativePath();
+	int err = stat(npath.c_str(), &s);
+	// does not exist, error, or is not a directory
+	return (-1 != err) && (0 != (s.st_mode & S_IFDIR));
+	// errno == ENOENT --> not exist
+#endif
+}
+
+bool Path::MkDir(const Path& path) {
+	if (!path) {
+		return false;
+	}
+#if defined(__unix__) || defined(__APPLE__)
+	int ret = mkdir(path.GetNativePath().c_str(), 0755);
+	return ret == 0 || errno == EEXIST;
+#elif defined(WIN32)
+	int ret = CreateDirectoryW(path.GetNativePath().c_str(), NULL);
+	return ret || (GetLastError() == ERROR_ALREADY_EXISTS);
+#else
+#error must implement Path::MkDir() for this OS
+#endif
+}
+
+void Path::Listing(const Path& path) {
+	if (!path) {
+		return;
+	}
+#if defined(WIN32)
+	WIN32_FIND_DATAW s;
+	auto npath = path.GetNativePath();
+	if (npath.back() != L'\\') {
+		npath.push_back(L'\\');
+	}
+	npath.push_back(L'*');
+	HANDLE search = FindFirstFileW(npath.c_str(), &s);
+	if (search == INVALID_HANDLE_VALUE) {
+		return;
+	}
+	do {
+		char ftype = '-';
+		if (s.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) {
+			ftype = 'l';
+		}
+		if (s.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+			ftype = 'd';
+		}
+		if (s.dwFileAttributes & FILE_ATTRIBUTE_DEVICE) {
+			ftype = 'v';
+		}
+		std::wcout << "[" << ftype << ":" << ((s.dwFileAttributes & FILE_ATTRIBUTE_ARCHIVE) ? "A" : "-")
+				   << ((s.dwFileAttributes & FILE_ATTRIBUTE_COMPRESSED) ? "C" : "-")
+				   << ((s.dwFileAttributes & FILE_ATTRIBUTE_ENCRYPTED) ? "E" : "-")
+				   << ((s.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) ? "H" : "-")
+				   << ((s.dwFileAttributes & FILE_ATTRIBUTE_READONLY) ? "R" : "-")
+				   << ((s.dwFileAttributes & FILE_ATTRIBUTE_SYSTEM) ? "S" : "-") << "] " << path << "\\" << s.cFileName
+				   << '\n';
+		if (0 == lstrcmpW(s.cFileName, L".") || 0 == lstrcmpW(s.cFileName, L"..")) {
+			continue;
+		}
+		Path::Listing(path / std::wstring(s.cFileName));
+	} while (FindNextFileW(search, &s));
+	FindClose(search);
+	return;
+#else
+	auto npath = path.GetNativePath();
+	if (npath.back() != L'/') {
+		npath.push_back(L'/');
+	}
+	DIR* dir = opendir(npath.c_str());
+	if (!dir) {
+		return;
+	}
+	dirent* entry = readdir(dir);
+	int dir_fd = dirfd(dir);
+	struct stat s;
+	while ((entry = readdir(dir))) {
+		int err = fstatat(dir_fd, entry->d_name, &s, 0);
+		if (0 == strcmp(entry->d_name, ".") || 0 == strcmp(entry->d_name, "..")) {
+			continue;
+		}
+		if (!err) {
+			err = faccessat(dir_fd, entry->d_name, R_OK | W_OK, 0);
+			char ftype = '?';
+			switch (s.st_mode & S_IFMT) {
+			case S_IFIFO: ftype = 'f'; break;
+			case S_IFCHR: ftype = 'c'; break;
+			case S_IFDIR: ftype = 'd'; break;
+			case S_IFBLK: ftype = 'b'; break;
+			case S_IFREG: ftype = '-'; break;
+			case S_IFLNK: ftype = 'l'; break;
+			case S_IFSOCK: ftype = 's'; break;
+			}
+			std::cout << "[" << ftype << ':' << (err ? "ro" : "rw") << "] " << npath << "|" << entry->d_name << '\n';
+			if (ftype == 'd') {
+				Path::Listing(path / std::string(entry->d_name));
+			}
+		}
+	}
+	closedir(dir);
+#endif
+}
+
+#if defined(WIN32)
+std::string winstrerror(DWORD errcode) {
+	LPSTR msgbuf = nullptr;
+	FormatMessageA(
+			FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
+			NULL,
+			errcode,
+			0,
+			(LPSTR)&msgbuf,
+			0x8000,
+			NULL);
+	if (!msgbuf) {
+		return {};
+	}
+	std::string ret(msgbuf);
+	LocalFree(msgbuf);
+	return ret;
+}
+std::wstring winwstrerror(DWORD errcode) {
+	LPWSTR msgbuf = nullptr;
+	FormatMessageW(
+			FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
+			NULL,
+			errcode,
+			0,
+			(LPWSTR)&msgbuf,
+			0x8000,
+			NULL);
+	if (!msgbuf) {
+		return {};
+	}
+	std::wstring ret(msgbuf);
+	LocalFree(msgbuf);
+	return ret;
+}
+#endif
+
+void Path::Remove(const Path& path) {
+	if (!path) {
+		throw PathException("invalid path");
+	}
+#if defined(WIN32)
+	auto npath = path.GetNativePath();
+	if (npath.back() == L'\\') {
+		npath.pop_back();
+	}
+	DWORD fa = GetFileAttributesW(npath.c_str());
+	if (fa == INVALID_FILE_ATTRIBUTES) {
+		std::wcout << "Can not remove file: " << npath << " : " << winwstrerror(GetLastError()) << '\n';
+		return;
+	}
+	const char* ftype = "file";
+	if (fa & FILE_ATTRIBUTE_REPARSE_POINT) {
+		ftype = "link";
+	}
+	int result = 0;
+	if (fa & FILE_ATTRIBUTE_DIRECTORY) {
+		ftype = "directory";
+		result = RemoveDirectoryW(npath.c_str());
+	}
+	else {
+		result = DeleteFileW(npath.c_str());
+	}
+	if (!result) {
+		std::stringstream msg;
+		msg << "Delete " << ftype << " failed: " << utf8_encode(npath) << " : " << winstrerror(GetLastError()) << '\n';
+		throw PathException(msg.str());
+	}
+#else
+	struct stat s;
+	auto npath = path.GetNativePath();
+	int err = stat(npath.c_str(), &s);
+	mode_t ftype = (s.st_mode & S_IFMT);
+	if (err) {
+		throw PathException(strerror(errno));
+	}
+	if (!(ftype == S_IFREG || ftype == S_IFDIR || ftype == S_IFLNK || ftype == S_IFSOCK)) {
+		// you really shouldn't be using the tec::Path API to deal with fifos/device nodes
+		// even symlinks and sockets are a bit of a stretch.
+		throw PathException("Not a removable object");
+	}
+	if ((s.st_mode & S_IFMT) == S_IFDIR) {
+		if (rmdir(npath.c_str())) {
+			throw PathException(strerror(errno));
+		}
+	}
+	else if (unlink(npath.c_str())) {
+		throw PathException(strerror(errno));
+	}
+#endif
+}
+
+size_t Path::RemoveAll(const Path& path) {
+	if (!path) {
+		throw PathException("invalid path");
+	}
+#if defined(WIN32)
+	auto npath = path.GetNativePath();
+	if (npath.back() == L'\\') {
+		npath.pop_back();
+	}
+	DWORD fa = GetFileAttributesW(npath.c_str());
+	if (fa == INVALID_FILE_ATTRIBUTES) {
+		throw PathException(winstrerror(GetLastError()));
+	}
+	if (0 == (fa & FILE_ATTRIBUTE_DIRECTORY)) { // not a directory
+		Remove(path);
+		return 1;
+	}
+#else
+	struct stat s;
+	auto npath = path.GetNativePath();
+	int err = stat(npath.c_str(), &s);
+	if (err) {
+		throw PathException(strerror(errno));
+	}
+	if ((s.st_mode & S_IFMT) != S_IFDIR) { // not a directory
+		Remove(path);
+		return 1;
+	}
+#endif
+	Path::CheckRemoveAll(path);
+	return RemoveAll_Internal(path);
+}
+
+size_t Path::RemoveAll_Internal(const Path& path) {
+	size_t removed_count = 0;
+#if defined(WIN32)
+	WIN32_FIND_DATAW s;
+	auto npath = path.GetNativePath();
+	if (npath.back() != L'\\') {
+		npath.push_back(L'\\');
+	}
+	npath.push_back(L'*');
+	HANDLE search = FindFirstFileW(npath.c_str(), &s);
+	if (search == INVALID_HANDLE_VALUE) {
+		throw PathException("can not access path");
+	}
+	do {
+		if (0 == lstrcmpW(s.cFileName, L".") || 0 == lstrcmpW(s.cFileName, L"..")) {
+			continue;
+		}
+		auto rmpath = path / std::wstring(s.cFileName);
+		auto rmnpath = rmpath.GetNativePath();
+		if (s.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+			removed_count += Path::RemoveAll_Internal(rmpath);
+		}
+		else {
+			std::wcout << "removing " << rmnpath << '\n';
+			// remove file
+			if (!DeleteFileW(rmnpath.c_str())) {
+				std::stringstream msg;
+				msg << "Delete file failed: " << utf8_encode(rmnpath) << " : " << winstrerror(GetLastError()) << '\n';
+				throw PathException(msg.str());
+			}
+			removed_count++;
+		}
+	} while (FindNextFileW(search, &s));
+	FindClose(search);
+	npath.pop_back(); // remove the slash star off the end
+	npath.pop_back();
+	std::wcout << "removing directory " << npath << '\n';
+	// remove directory
+	if (!RemoveDirectoryW(npath.c_str())) {
+		std::stringstream msg;
+		msg << "Delete file failed: " << utf8_encode(npath) << " : " << winstrerror(GetLastError()) << '\n';
+		throw PathException(msg.str());
+	}
+	removed_count++;
+#else
+	auto npath = path.GetNativePath();
+	if (npath.back() != L'/') {
+		npath.push_back(L'/');
+	}
+	DIR* dir = opendir(npath.c_str());
+	if (!dir) {
+		throw PathException("can not access path");
+	}
+	dirent* entry = readdir(dir);
+	int dir_fd = dirfd(dir);
+	struct stat s;
+	while ((entry = readdir(dir))) {
+		int err = fstatat(dir_fd, entry->d_name, &s, 0);
+		if (0 == strcmp(entry->d_name, ".") || 0 == strcmp(entry->d_name, "..")) {
+			continue;
+		}
+		if (!err) {
+			mode_t ftype = (s.st_mode & S_IFMT);
+			auto rmpath = path / std::string(entry->d_name);
+			if (ftype == S_IFDIR) {
+				// recurse to remove directory and all files in it
+				removed_count += Path::RemoveAll_Internal(rmpath);
+			}
+			else if (ftype == S_IFREG || ftype == S_IFLNK || ftype == S_IFSOCK) {
+				// remove file
+				std::cout << "removing " << rmpath.GetNativePath() << '\n';
+				if (unlinkat(dir_fd, entry->d_name, 0)) {
+					throw PathException(strerror(errno));
+				}
+				removed_count++;
+			}
+		}
+	}
+	closedir(dir);
+	std::cout << "removing directory " << npath << '\n';
+	if (rmdir(npath.c_str())) {
+		throw PathException(strerror(errno));
+	}
+	removed_count++;
+#endif
+	return removed_count;
+}
+
+void Path::CheckRemoveAll(const Path& path) {
+	if (!path) {
+		throw PathException("invalid path");
+	}
+	if (path.path.size() == 1 && path.path[0] == '/') {
+		throw PathException("can not RemoveAll at root");
+	}
+#if defined(WIN32)
+	WIN32_FIND_DATAW s;
+	auto npath = path.GetNativePath();
+	if (npath.back() != L'\\') {
+		npath.push_back(L'\\');
+	}
+	npath.push_back(L'*');
+	HANDLE search = FindFirstFileW(npath.c_str(), &s);
+	if (search == INVALID_HANDLE_VALUE) {
+		throw PathException("Search failed");
+	}
+	do {
+		if (0 == lstrcmpW(s.cFileName, L".") || 0 == lstrcmpW(s.cFileName, L"..")) {
+			continue; // don't check these (that would recurse!)
+		}
+		if (s.dwFileAttributes & (FILE_ATTRIBUTE_DEVICE | FILE_ATTRIBUTE_SYSTEM | FILE_ATTRIBUTE_READONLY)) {
+			throw PathException("Non-removable object");
+		}
+		DWORD open_flags = 0;
+		if (s.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) {
+			open_flags |= FILE_FLAG_OPEN_REPARSE_POINT;
+		}
+		if (s.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+			open_flags |= FILE_FLAG_BACKUP_SEMANTICS;
+		}
+		auto checkpath = path / std::wstring(s.cFileName);
+		auto ncheckpath = checkpath.GetNativePath();
+		HANDLE file = CreateFileW(ncheckpath.c_str(), DELETE, 0, NULL, OPEN_EXISTING, open_flags, NULL);
+		if (file == INVALID_HANDLE_VALUE) {
+			throw PathException("Non-removable object: access check failed");
+		}
+		CloseHandle(file);
+		if (s.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+			Path::CheckRemoveAll(checkpath);
+		}
+	} while (FindNextFileW(search, &s));
+	FindClose(search);
+	return;
+#else
+	auto npath = path.GetNativePath();
+	if (npath.back() != L'/') {
+		npath.push_back(L'/');
+	}
+	DIR* dir = opendir(npath.c_str());
+	if (!dir) {
+		throw PathException("Search failed");
+	}
+	dirent* entry = readdir(dir);
+	int dir_fd = dirfd(dir);
+	struct stat s;
+	while ((entry = readdir(dir))) {
+		int err = fstatat(dir_fd, entry->d_name, &s, 0);
+		if (0 == strcmp(entry->d_name, ".") || 0 == strcmp(entry->d_name, "..")) {
+			continue; // don't check these (that would recurse!)
+		}
+		if (!err) {
+			err = faccessat(dir_fd, entry->d_name, R_OK | W_OK, 0);
+			if (err) {
+				throw PathException("Non-removable object: access check failed");
+			}
+			mode_t ftype = (s.st_mode & S_IFMT);
+			if (!(ftype == S_IFREG || ftype == S_IFDIR || ftype == S_IFLNK || ftype == S_IFSOCK)) {
+				throw PathException("Not a removable object");
+			}
+			if (ftype == S_IFDIR) {
+				auto checkpath = path / std::string(entry->d_name);
+				Path::CheckRemoveAll(checkpath);
+			}
+		}
+	}
+	closedir(dir);
+#endif
+}
+
 Path Path::GetUserSettingsPath() {
 	// Try to use cached value
-	if (!Path::settings_folder.empty()) {
-		return Path(Path::settings_folder);
+	if (Path::settings_folder) {
+		return Path::settings_folder;
 	}
 	Path ret;
-
 #if defined(__APPLE__)
 	char* home = getenv("HOME");
-	ret = home;
+	if (home == nullptr) {
+		return Path::invalid_path;
+	}
+	ret = std::string(home);
 	ret /= "Library";
 	ret /= "Preferences";
 	ret /= app_name;
-	ret.path += PATH_SEPARATOR;
-
+	// $HOME/Library/Preferences/trillek/
 #elif defined(__unix__)
 	char* home = getenv("XDG_CONFIG_HOME");
 	if (home == nullptr) {
 		home = getenv("HOME");
 		if (home == nullptr) {
-			return Path();
+			return Path::invalid_path;
 		}
 	}
-	ret = home;
+	ret = std::string(home);
 	ret /= ".config";
 	ret /= app_name;
-	ret.path += PATH_SEPARATOR;
-
+	// $HOME/.config/trillek/
 #elif defined(WIN32)
 	LPWSTR wszPath = nullptr;
-
 	if (!SUCCEEDED(SHGetKnownFolderPath(FOLDERID_RoamingAppData, 0, nullptr, &wszPath))) {
-		return Path();
+		return Path::invalid_path;
 	}
-
-	_bstr_t bstrPath(wszPath);
-	std::wstring wpath((wchar_t*)bstrPath);
-	ret = tec::utf8_encode(wpath);
+	std::wstring wpath((wchar_t*)wszPath);
 	CoTaskMemFree(wszPath);
+	ret = tec::utf8_encode(wpath);
 	ret /= app_name;
-	ret.path += PATH_SEPARATOR;
-
+	// %APPDATA%/trillek/
 #endif
+	// add the application name
+	ret.path += PATH_SEPARATOR;
 	Path::MkPath(ret);
-	Path::settings_folder = ret.toString();
+	Path::settings_folder = ret;
 	return ret;
 
 } // End of GetUserSettingsPath
 
 Path Path::GetUserDataPath() {
 	// Try to use cached value
-	if (!Path::udata_folder.empty()) {
-		return Path(Path::udata_folder);
+	if (Path::udata_folder) {
+		return Path::udata_folder;
 	}
-
-#if defined(__unix__)
+	Path ret;
+#if defined(__APPLE__)
+	char* home = getenv("HOME");
+	if (home == nullptr) {
+		return Path::invalid_path;
+	}
+	// OSX $HOME/Library/Application\ Support/trillek/data/
+	ret = std::string(home);
+	ret /= "Library";
+	ret /= "Application Support";
+	ret /= app_name;
+	ret /= "data";
+#elif defined(__unix__)
 	char* home = getenv("XDG_DATA_HOME");
 	if (home == nullptr) {
 		home = getenv("HOME");
 		if (home == nullptr) {
-			return Path();
+			return Path::invalid_path;
 		}
 	}
-	Path ret = Path(std::string(home));
+	ret = Path(std::string(home));
+	// $HOME/.local/share/trillek/
 	ret /= ".local/share";
 	ret /= app_name;
+#elif defined(WIN32)
+	ret = Path::GetUserSettingsPath();
+	if (!ret) {
+		return Path::invalid_path;
+	}
+	// Win %APPDATA%/trillek/data/
+	ret /= "data";
+#else
+#error must implement Path::GetUserDataPath() for this OS
+#endif
 	ret.path += PATH_SEPARATOR;
-	Path::udata_folder = ret.toString();
-
+	Path::udata_folder = ret;
 	Path::MkPath(ret);
 	return ret;
-#elif defined(WIN32) || defined(__APPLE__)
-	auto path = Path::GetUserSettingsPath();
-	if (path.empty()) {
-		return path;
-	}
-	path /= "data";
-	path.path += PATH_SEPARATOR;
-	Path::udata_folder = path.toString();
-
-	Path::MkPath(path);
-	return path;
-#else
-	return Path();
-#endif
-
 } // End of GetUserDataPath
 
 Path Path::GetUserCachePath() {
 	// Try to use cached value
-	if (!Path::cache_folder.empty()) {
-		return Path(Path::cache_folder);
+	if (Path::cache_folder) {
+		return Path::cache_folder;
 	}
-
+	Path ret;
 #if defined(__APPLE__)
-	auto path = GetUserSettingsPath();
-	if (path.empty()) {
-		return Path();
+	char* home = getenv("HOME");
+	if (home == nullptr) {
+		return Path::invalid_path;
 	}
-	path /= "cache";
-	path.path += PATH_SEPARATOR;
+	ret = std::string(home);
+	ret /= "Library";
+	ret /= "Application Support";
+	ret /= app_name;
+	ret /= "cache";
+	// $HOME/Library/Application Support/trillek/cache/
 #elif defined(__unix__)
 	char* home = getenv("XDG_CACHE_HOME");
 	if (home == nullptr) {
 		home = getenv("HOME");
 		if (home == nullptr) {
-			return Path();
+			return Path::invalid_path;
 		}
 	}
-	Path path = Path(std::string(home));
-	path /= ".cache";
-	path /= app_name;
-	path.path += PATH_SEPARATOR;
+	ret = Path(std::string(home));
+	ret /= ".cache";
+	ret /= app_name;
+	// $HOME/.cache/trillek/
 #elif defined(WIN32)
 	LPWSTR wszPath = nullptr;
-
 	if (!SUCCEEDED(SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &wszPath))) {
-		return Path();
+		return Path::invalid_path;
 	}
-
-	_bstr_t bstrPath(wszPath);
-	std::wstring wpath((wchar_t*)bstrPath);
-	Path path(tec::utf8_encode(wpath));
+	ret = Path(std::wstring(wszPath));
 	CoTaskMemFree(wszPath);
-	path /= app_name;
-	path.path += PATH_SEPARATOR;
-
+	ret /= app_name;
+	// %LOCALAPPDATA%/trillek/
 #endif
-	Path::cache_folder = path.toString();
-	Path::MkPath(path);
-	return path;
+	ret.path += PATH_SEPARATOR;
+	Path::cache_folder = ret;
+	Path::MkPath(ret);
+	return ret;
 } // End of GetUserCachePath
 
 Path Path::GetProgramPath() {
@@ -172,8 +594,9 @@ Path Path::GetProgramPath() {
 	std::string tmp;
 	tmp.resize(PATH_MAX);
 	uint32_t size = tmp.size();
+	// Mac OS X: _NSGetExecutablePath() see: man 3 dyld
 	if (_NSGetExecutablePath(tmp.data(), &size) == 0) {
-		tmp.resize(size);
+		tmp.resize(tmp.find_first_of('\0'));
 		return Path(tmp);
 	}
 	else {
@@ -183,31 +606,63 @@ Path Path::GetProgramPath() {
 		return Path(tmp);
 	}
 #elif defined(__linux__)
+	// yes this is __linux__ not __unix__ because it's kernel specific, but other unix-like are similar
 	std::string tmp;
 	tmp.resize(PATH_MAX);
+	// Linux: readlink /proc/self/exe
 	ssize_t bytes = readlink("/proc/self/exe", tmp.data(), tmp.size());
 	if (bytes == -1) {
-		return Path();
+		return Path::invalid_path;
 	}
 	tmp.resize(bytes);
 	return Path(tmp);
 #elif defined(WIN32)
 	std::wstring wstr;
-	wstr.resize(MAX_PATH);
-	wstr.resize(GetModuleFileNameW(nullptr, wstr.data(), (DWORD)wstr.size()));
-
+	wstr.resize(1024);
+	// GetModuleFileNameW(HMODULE hModule, LPWSTR lpFilename, DWORD nSize)
+	// hModule -> module handle or NULL for current
+	// lpFilename -> pointer to buffer to hold wide characters
+	// nSize -> number of *characters* (not bytes) in buffer.
+	// return -> length of copied string, not including nul char.
+	// truncated names will return nSize with GetLastError() == ERROR_INSUFFICIENT_BUFFER
+	DWORD set_size = wstr.size();
+	while ((wstr.size() == set_size) && (set_size <= 0x8000)) {
+		wstr.resize(GetModuleFileNameW(nullptr, wstr.data(), set_size));
+		if (GetLastError() == ERROR_INSUFFICIENT_BUFFER) {
+			set_size += 1024;
+			wstr.resize(set_size);
+		}
+	}
 	return Path(wstr);
 #else
-	// Other *NIX have his proper API or changes on procfs
-	//  * Mac OS X: _NSGetExecutablePath() (man 3 dyld)
-	//  * Linux: readlink /proc/self/exe
+//#elif defined(__some_fancy_new_os__)
+#error must implement Path::GetProgramPath() for this OS
+	// Other Unix-like OS should provide this via an API or changes in procfs
 	//  * Solaris: getexecname()
 	//  * FreeBSD: sysctl CTL_KERN KERN_PROC KERN_PROC_PATHNAME -1
-	//  * FreeBSD if it has procfs: readlink /proc/curproc/file (FreeBSD doesn't have procfs by
-	//  default)
+	//  * FreeBSD with procfs: readlink /proc/curproc/file
+	//    (FreeBSD doesn't typically have or mount procfs by default)
 	//  * NetBSD: readlink /proc/curproc/exe
 	//  * DragonFly BSD: readlink /proc/curproc/file
 #endif
+}
+
+// Try to get current working directory (i.e. where the program was called from)
+Path Path::GetWorkingDir() {
+	Path::NativePath cwd;
+	cwd.resize(FILENAME_MAX);
+	constexpr Path::NativePath::value_type nullchar = 0;
+#if defined(WIN32)
+	if (!GetCurrentDirectoryW((DWORD)cwd.size(), cwd.data())) {
+#else
+	if (!getcwd(cwd.data(), cwd.size())) {
+#endif
+		// The working directory is kind of important
+		return Path::invalid_path;
+	}
+	cwd.resize(std::min(cwd.find_first_of(nullchar), cwd.size()));
+	// Search for the assets folder
+	return Path(cwd);
 }
 
 } // namespace tec

--- a/common/filesystem_platform.cpp
+++ b/common/filesystem_platform.cpp
@@ -1,0 +1,213 @@
+#include "filesystem.hpp"
+
+// Stuff to get OS libs for paths
+#if defined(__APPLE__)
+#include <CoreServices/CoreServices.h>
+#include <mach-o/dyld.h>
+#include <unistd.h>
+
+#elif defined(__unix__)
+#include <limits.h>
+#include <unistd.h>
+
+#elif defined(WIN32)
+#ifndef UNICODE
+#define UNICODE 1
+#endif
+#include <Shlobj.h>
+#include <Windows.h>
+#include <comutil.h>
+#include <direct.h>
+#undef max
+#undef min
+
+#pragma comment(lib, "comsuppw")
+#endif
+
+#ifndef PATH_MAX
+#define PATH_MAX 1024 // same with Mac OS X's syslimits.h
+#endif
+
+#ifndef TEXT
+#define TEXT(a) a
+#endif
+
+namespace tec {
+
+Path Path::GetUserSettingsPath() {
+	// Try to use cached value
+	if (!Path::settings_folder.empty()) {
+		return Path(Path::settings_folder);
+	}
+	Path ret;
+
+#if defined(__APPLE__)
+	char* home = getenv("HOME");
+	ret = home;
+	ret /= "Library";
+	ret /= "Preferences";
+	ret /= app_name;
+	ret.path += PATH_SEPARATOR;
+
+#elif defined(__unix__)
+	char* home = getenv("XDG_CONFIG_HOME");
+	if (home == nullptr) {
+		home = getenv("HOME");
+		if (home == nullptr) {
+			return Path();
+		}
+	}
+	ret = home;
+	ret /= ".config";
+	ret /= app_name;
+	ret.path += PATH_SEPARATOR;
+
+#elif defined(WIN32)
+	LPWSTR wszPath = nullptr;
+
+	if (!SUCCEEDED(SHGetKnownFolderPath(FOLDERID_RoamingAppData, 0, nullptr, &wszPath))) {
+		return Path();
+	}
+
+	_bstr_t bstrPath(wszPath);
+	std::wstring wpath((wchar_t*)bstrPath);
+	ret = tec::utf8_encode(wpath);
+	CoTaskMemFree(wszPath);
+	ret /= app_name;
+	ret.path += PATH_SEPARATOR;
+
+#endif
+	Path::MkPath(ret);
+	Path::settings_folder = ret.toString();
+	return ret;
+
+} // End of GetUserSettingsPath
+
+Path Path::GetUserDataPath() {
+	// Try to use cached value
+	if (!Path::udata_folder.empty()) {
+		return Path(Path::udata_folder);
+	}
+
+#if defined(__unix__)
+	char* home = getenv("XDG_DATA_HOME");
+	if (home == nullptr) {
+		home = getenv("HOME");
+		if (home == nullptr) {
+			return Path();
+		}
+	}
+	Path ret = Path(std::string(home));
+	ret /= ".local/share";
+	ret /= app_name;
+	ret.path += PATH_SEPARATOR;
+	Path::udata_folder = ret.toString();
+
+	Path::MkPath(ret);
+	return ret;
+#elif defined(WIN32) || defined(__APPLE__)
+	auto path = Path::GetUserSettingsPath();
+	if (path.empty()) {
+		return path;
+	}
+	path /= "data";
+	path.path += PATH_SEPARATOR;
+	Path::udata_folder = path.toString();
+
+	Path::MkPath(path);
+	return path;
+#else
+	return Path();
+#endif
+
+} // End of GetUserDataPath
+
+Path Path::GetUserCachePath() {
+	// Try to use cached value
+	if (!Path::cache_folder.empty()) {
+		return Path(Path::cache_folder);
+	}
+
+#if defined(__APPLE__)
+	auto path = GetUserSettingsPath();
+	if (path.empty()) {
+		return Path();
+	}
+	path /= "cache";
+	path.path += PATH_SEPARATOR;
+#elif defined(__unix__)
+	char* home = getenv("XDG_CACHE_HOME");
+	if (home == nullptr) {
+		home = getenv("HOME");
+		if (home == nullptr) {
+			return Path();
+		}
+	}
+	Path path = Path(std::string(home));
+	path /= ".cache";
+	path /= app_name;
+	path.path += PATH_SEPARATOR;
+#elif defined(WIN32)
+	LPWSTR wszPath = nullptr;
+
+	if (!SUCCEEDED(SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &wszPath))) {
+		return Path();
+	}
+
+	_bstr_t bstrPath(wszPath);
+	std::wstring wpath((wchar_t*)bstrPath);
+	Path path(tec::utf8_encode(wpath));
+	CoTaskMemFree(wszPath);
+	path /= app_name;
+	path.path += PATH_SEPARATOR;
+
+#endif
+	Path::cache_folder = path.toString();
+	Path::MkPath(path);
+	return path;
+} // End of GetUserCachePath
+
+Path Path::GetProgramPath() {
+#if defined(__APPLE__)
+	std::string tmp;
+	tmp.resize(PATH_MAX);
+	uint32_t size = tmp.size();
+	if (_NSGetExecutablePath(tmp.data(), &size) == 0) {
+		tmp.resize(size);
+		return Path(tmp);
+	}
+	else {
+		// Too small buffer
+		tmp.resize(size);
+		_NSGetExecutablePath(tmp.data(), &size);
+		return Path(tmp);
+	}
+#elif defined(__linux__)
+	std::string tmp;
+	tmp.resize(PATH_MAX);
+	ssize_t bytes = readlink("/proc/self/exe", tmp.data(), tmp.size());
+	if (bytes == -1) {
+		return Path();
+	}
+	tmp.resize(bytes);
+	return Path(tmp);
+#elif defined(WIN32)
+	std::wstring wstr;
+	wstr.resize(MAX_PATH);
+	wstr.resize(GetModuleFileNameW(nullptr, wstr.data(), (DWORD)wstr.size()));
+
+	return Path(wstr);
+#else
+	// Other *NIX have his proper API or changes on procfs
+	//  * Mac OS X: _NSGetExecutablePath() (man 3 dyld)
+	//  * Linux: readlink /proc/self/exe
+	//  * Solaris: getexecname()
+	//  * FreeBSD: sysctl CTL_KERN KERN_PROC KERN_PROC_PATHNAME -1
+	//  * FreeBSD if it has procfs: readlink /proc/curproc/file (FreeBSD doesn't have procfs by
+	//  default)
+	//  * NetBSD: readlink /proc/curproc/exe
+	//  * DragonFly BSD: readlink /proc/curproc/file
+#endif
+}
+
+} // namespace tec

--- a/common/lua-system.cpp
+++ b/common/lua-system.cpp
@@ -47,13 +47,13 @@ LuaSystem::LuaSystem() {
 	this->lua.add_package_loader(
 			[this](sol::string_view package_name) -> sol::protected_function {
 				spdlog::get("console_log")->debug("request to load Lua package \"{}\"", package_name);
-				static FilePath scripts_base = FilePath::GetAssetsBasePath() / "scripts";
+				static Path scripts_base = Path::GetAssetPath("scripts");
 				std::string package_path(package_name.data(), package_name.size());
 				if (package_path.find_first_of('.') == std::string::npos) {
 					package_path.append(".lua");
 				}
 				// for now, we are going to look for a single lua file with by the same name as the package
-				FilePath package_script_path = scripts_base / package_path;
+				Path package_script_path = scripts_base / package_path;
 				std::string source;
 				if (!package_script_path.FileExists()) {
 					return sol::nil;
@@ -169,7 +169,7 @@ std::list<sol::protected_function> LuaSystem::GetAllFunctions(std::string functi
 	return functions;
 }
 
-std::shared_ptr<LuaScript> LuaSystem::LoadFile(FilePath filepath) {
+std::shared_ptr<LuaScript> LuaSystem::LoadFile(Path filepath) {
 	std::shared_ptr<LuaScript> script = std::make_shared<LuaScript>(ScriptFile::Create(filepath));
 	script->SetupEnvironment(&this->lua);
 	script->ReloadScript();

--- a/common/lua-system.hpp
+++ b/common/lua-system.hpp
@@ -39,7 +39,7 @@ public:
 
 	void ExecuteString(std::string script_string);
 
-	std::shared_ptr<LuaScript> LoadFile(FilePath filepath);
+	std::shared_ptr<LuaScript> LoadFile(Path filepath);
 
 	sol::state& GetGlobalState() { return this->lua; }
 

--- a/common/proto-load.cpp
+++ b/common/proto-load.cpp
@@ -36,7 +36,7 @@ bool SaveFromString(const Path& fname, std::string contents) {
 // Loads a given entity json file
 bool LoadProtoPack(const Path& fname, proto::Entity& entity) {
 	auto _log = spdlog::get("console_log");
-	if (!fname.isValidPath() || !fname.FileExists()) {
+	if (!fname || !fname.FileExists()) {
 		_log->error("bad path or missing protopack file: {}", fname.toString());
 		return false;
 	}
@@ -61,7 +61,7 @@ void ProtoLoadEntity(const Path& fname) {
 void ProtoLoad(std::string filename) {
 	auto _log = spdlog::get("console_log");
 	Path fname = Path::GetAssetPath(filename);
-	if (!fname.isValidPath() || !fname.FileExists()) {
+	if (!fname || !fname.FileExists()) {
 		_log->error("[ProtoLoad] Bad path or missing file: {}\n", fname.FileName());
 		return;
 	}

--- a/common/proto-load.cpp
+++ b/common/proto-load.cpp
@@ -9,7 +9,7 @@
 
 namespace tec {
 
-std::string LoadAsString(const FilePath& fname) {
+std::string LoadAsString(const Path& fname) {
 	std::fstream input(fname.GetNativePath(), std::ios::in | std::ios::binary);
 	if (!input.good())
 		throw std::runtime_error("can't open ." + fname.toString());
@@ -23,7 +23,7 @@ std::string LoadAsString(const FilePath& fname) {
 	return in;
 }
 
-bool SaveFromString(const FilePath& fname, std::string contents) {
+bool SaveFromString(const Path& fname, std::string contents) {
 	std::fstream output(fname.GetNativePath(), std::ios::out);
 	if (!output.good())
 		throw std::runtime_error("can't open ." + fname.toString());
@@ -34,7 +34,7 @@ bool SaveFromString(const FilePath& fname, std::string contents) {
 }
 
 // Loads a given entity json file
-bool LoadProtoPack(const FilePath& fname, proto::Entity& entity) {
+bool LoadProtoPack(const Path& fname, proto::Entity& entity) {
 	auto _log = spdlog::get("console_log");
 	if (!fname.isValidPath() || !fname.FileExists()) {
 		_log->error("bad path or missing protopack file: {}", fname.toString());
@@ -51,7 +51,7 @@ bool LoadProtoPack(const FilePath& fname, proto::Entity& entity) {
 }
 
 // Loads a given json file into the system
-void ProtoLoadEntity(const FilePath& fname) {
+void ProtoLoadEntity(const Path& fname) {
 	std::shared_ptr<EntityCreated> data = std::make_shared<EntityCreated>();
 	if (LoadProtoPack(fname, data->entity)) {
 		EventSystem<EntityCreated>::Get()->Emit(data);
@@ -60,7 +60,7 @@ void ProtoLoadEntity(const FilePath& fname) {
 
 void ProtoLoad(std::string filename) {
 	auto _log = spdlog::get("console_log");
-	FilePath fname = FilePath::GetAssetPath(filename);
+	Path fname = Path::GetAssetPath(filename);
 	if (!fname.isValidPath() || !fname.FileExists()) {
 		_log->error("[ProtoLoad] Bad path or missing file: {}\n", fname.FileName());
 		return;
@@ -74,7 +74,7 @@ void ProtoLoad(std::string filename) {
 	}
 	_log->debug("[ProtoLoad] :\n {}", elist.DebugString());
 	for (int i = 0; i < elist.entity_file_list_size(); i++) {
-		FilePath entity_filename = FilePath::GetAssetPath(elist.entity_file_list(i));
+		Path entity_filename = Path::GetAssetPath(elist.entity_file_list(i));
 		ProtoLoadEntity(entity_filename);
 	}
 }

--- a/common/proto-load.hpp
+++ b/common/proto-load.hpp
@@ -9,15 +9,15 @@
 namespace tec {
 
 // Load the contents of a file as a string
-std::string LoadAsString(const FilePath& fname);
+std::string LoadAsString(const Path& fname);
 
 // Save a string directly to a file
-bool SaveFromString(const FilePath& fname, std::string contents);
+bool SaveFromString(const Path& fname, std::string contents);
 
 // Loads a given json file into a reference
-bool LoadProtoPack(const FilePath& fname, proto::Entity& entity);
+bool LoadProtoPack(const Path& fname, proto::Entity& entity);
 
 // Loads a given json file and emits it into the system
-void ProtoLoadEntity(const FilePath& fname);
+void ProtoLoadEntity(const Path& fname);
 
 } // namespace tec

--- a/common/resources/mesh.cpp
+++ b/common/resources/mesh.cpp
@@ -1,3 +1,13 @@
 #include "mesh.hpp"
 
-namespace tec {}
+namespace tec {
+
+MeshFile::~MeshFile() {
+	for (Mesh* mesh : this->meshes) {
+		if (mesh) {
+			delete mesh;
+		}
+	}
+}
+
+} // namespace tec

--- a/common/resources/mesh.hpp
+++ b/common/resources/mesh.hpp
@@ -122,13 +122,7 @@ struct Mesh final {
 
 class MeshFile {
 public:
-	virtual ~MeshFile() {
-		for (Mesh* mesh : this->meshes) {
-			if (mesh) {
-				delete mesh;
-			}
-		}
-	}
+	virtual ~MeshFile();
 
 	/**
 	* \brief Creates a new mesh and adds it to this file.

--- a/common/resources/script-file.cpp
+++ b/common/resources/script-file.cpp
@@ -1,3 +1,41 @@
 #include "script-file.hpp"
 
-namespace tec {}
+namespace tec {
+
+std::shared_ptr<ScriptFile> ScriptFile::Create(const Path& fname) {
+	auto scriptfile = std::make_shared<ScriptFile>();
+	scriptfile->SetName(fname.SubpathFrom("scripts", true).toString());
+
+	if (scriptfile->Load(fname)) {
+		ScriptMap::Set(scriptfile->GetName(), scriptfile);
+		return scriptfile;
+	}
+	spdlog::get("console_log")->warn("[ScriptFile] Error loading script file {}", fname.toString());
+
+	return nullptr;
+}
+
+bool ScriptFile::Load(const Path& _filename) {
+	auto _log = spdlog::get("console_log");
+	if (!_filename.isValidPath() || !_filename.FileExists()) {
+		_log->warn("[Script] Error loading scriptfile {}. Invalid path.", _filename.FileName());
+		return false;
+	}
+	auto file = _filename.OpenStream();
+	if (!file->is_open()) {
+		_log->warn("[Script] Error loading scriptfile {}", _filename.FileName());
+		return false;
+	}
+	file->seekg(0, std::ios::end);
+	script.reserve(static_cast<std::size_t>(file->tellg())); // Allocate string to the file size
+	file->seekg(0, std::ios::beg);
+
+	script = std::string((std::istreambuf_iterator<char>(*file)), std::istreambuf_iterator<char>());
+	_log->trace("[Script] Read script file {} of {} bytes", _filename.FileName(), script.length());
+	this->filename = _filename;
+
+	_log->debug("[Script] Loaded scriptfile {}", _filename.FileName());
+	return true;
+}
+
+} // namespace tec

--- a/common/resources/script-file.cpp
+++ b/common/resources/script-file.cpp
@@ -17,7 +17,7 @@ std::shared_ptr<ScriptFile> ScriptFile::Create(const Path& fname) {
 
 bool ScriptFile::Load(const Path& _filename) {
 	auto _log = spdlog::get("console_log");
-	if (!_filename.isValidPath() || !_filename.FileExists()) {
+	if (!_filename || !_filename.FileExists()) {
 		_log->warn("[Script] Error loading scriptfile {}. Invalid path.", _filename.FileName());
 		return false;
 	}

--- a/common/resources/script-file.hpp
+++ b/common/resources/script-file.hpp
@@ -27,59 +27,24 @@ public:
 	* \param[in] const std::vector<Property>& properties The creation properties for the resource.
 	* \return std::shared_ptr<ScriptFile> The created ScriptFile resource.
 	*/
-	static std::shared_ptr<ScriptFile> Create(const FilePath& fname) {
-		auto scriptfile = std::make_shared<ScriptFile>();
-		scriptfile->SetName(fname.SubpathFrom("assets").toGenericString());
-
-		if (scriptfile->Load(fname)) {
-			ScriptMap::Set(scriptfile->GetName(), scriptfile);
-			return scriptfile;
-		}
-		spdlog::get("console_log")->warn("[ScriptFile] Error loading script file {}", fname.toString());
-
-		return nullptr;
-	}
+	static std::shared_ptr<ScriptFile> Create(const Path& fname);
 
 	/**
 	* \brief Returns a resource with the specified name.
 	*
-	* \param[in] const FilePath filename The filename of the image file to load.
+	* \param[in] const Path filename The filename of the image file to load.
 	* \return bool True if initialization finished with no errors.
 	*/
-	bool Load(const FilePath& _filename) {
-		auto _log = spdlog::get("console_log");
-		if (_filename.isValidPath() && _filename.FileExists()) {
-			std::fstream file(_filename.GetNativePath(), std::ios_base::in);
-			if (file.is_open()) {
-				file.seekg(0, std::ios::end);
-				script.reserve(static_cast<std::size_t>(file.tellg())); // Allocate string to the file size
-				file.seekg(0, std::ios::beg);
-
-				script = std::string((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
-				_log->trace("[Script] Read script file {} of {} bytes", _filename.FileName(), script.length());
-				this->filename = _filename;
-			}
-			else {
-				_log->warn("[Script] Error loading scriptfile {}", _filename.FileName());
-				return false;
-			}
-		}
-		else {
-			_log->warn("[Script] Error loading scriptfile {}. Invalid path.", _filename.FileName());
-			return false;
-		}
-		_log->trace("[Script] Loaded scriptfile {}", _filename.FileName());
-		return true;
-	}
+	bool Load(const Path& _filename);
 
 	/**
 	* \brief Factory method that creates a Script and stores it in the
 	* ScriptMap under name. It will optionally load a script file with the given filename.
 	* \param const std::string name The name to store the PixelBuffer under.
-	* \param const FilePath filename The optional filename of the script to load.
+	* \param const Path filename The optional filename of the script to load.
 	* \return std::shared_ptr<ScriptFile> The created PixelBuffer.
 	*/
-	static std::shared_ptr<ScriptFile> Create(const std::string name, const FilePath& filename = FilePath()) {
+	static std::shared_ptr<ScriptFile> Create(const std::string name, const Path& filename = Path()) {
 		auto scr = std::make_shared<ScriptFile>();
 		ScriptMap::Set(name, scr);
 		if (!filename.empty()) {
@@ -121,7 +86,7 @@ public:
 protected:
 	std::string name;
 	std::string script;
-	FilePath filename;
+	Path filename;
 	bool dirty{false};
 };
 } // namespace tec

--- a/common/vcomputer-system.cpp
+++ b/common/vcomputer-system.cpp
@@ -93,7 +93,8 @@ void Computer::In(const proto::Component& source) {
 	}
 
 	std::string fname{comp.rom_file()};
-	int size = LoadROM(FilePath::GetAssetPath(fname).toString(), this->rom);
+	auto file = Path::GetAssetPath(fname).OpenStream();
+	int size = LoadROM(*file, this->rom);
 	if (size < 0) {
 		std::shared_ptr<spdlog::logger> _log = spdlog::get("console_log");
 		_log->error("An error occoured while reading file {}", fname);

--- a/server/lua-types.cpp
+++ b/server/lua-types.cpp
@@ -11,15 +11,15 @@ TEC_RegisterLuaType(tec, SaveGame) {
 		"SaveGame", sol::no_constructor,
 		/*"load", sol::overload(
 			sol::resolve<bool(std::string)>(&SaveGame::Load),
-			sol::resolve<bool(FilePath)>(&SaveGame::Load)
+			sol::resolve<bool(Path)>(&SaveGame::Load)
 		), */
 		"save", sol::overload(
 			sol::resolve<bool()>(&SaveGame::Save)/*,
-			sol::resolve<bool(FilePath)>(&SaveGame::Save)*/
+			sol::resolve<bool(Path)>(&SaveGame::Save)*/
 		),
 		"reload", sol::overload(
 			sol::resolve<bool()>(&SaveGame::Reload)/*,
-			sol::resolve<bool(FilePath)>(&SaveGame::Reload)*/
+			sol::resolve<bool(Path)>(&SaveGame::Reload)*/
 		),
 		"user_list", sol::readonly(&SaveGame::user_list)
 	);

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -64,10 +64,10 @@ int main() {
 	// use constant mode stepping, because we don't need interpolated states on the server
 	simulation.GetPhysicsSystem().SetSubstepping(0);
 
-	tec::FilePath save_directory = tec::FilePath::GetAssetPath("save");
+	tec::Path save_directory = tec::Path::GetAssetPath("save");
 
 	if (!save_directory.DirExists()) {
-		tec::FilePath::MkPath(save_directory);
+		tec::Path::MkPath(save_directory);
 	}
 
 	try {
@@ -77,7 +77,7 @@ int main() {
 		const auto lua_sys = server.GetLuaSystem();
 
 		tec::SaveGame save;
-		save.Load(tec::FilePath::GetAssetPath("save/save1.json"));
+		save.Load(tec::Path::GetAssetPath("save/save1.json"));
 		lua_sys->GetGlobalState()["save"] = &save;
 
 		auto& authenticator = server.GetAuthenticator();
@@ -85,7 +85,7 @@ int main() {
 		authenticator.SetDataSource(&user_list_data_source);
 
 		// Load test script
-		tec::FilePath fp = tec::FilePath::GetAssetPath("scripts/server-test.lua");
+		tec::Path fp = tec::Path::GetAssetPath("scripts/server-test.lua");
 		if (fp.FileExists()) {
 			lua_sys->LoadFile(fp);
 		}

--- a/server/save-game.cpp
+++ b/server/save-game.cpp
@@ -68,7 +68,7 @@ bool SaveGame::Save() { return this->Save(this->filepath); }
 
 bool SaveGame::Save(const Path _filepath) {
 	auto _log = spdlog::get("console_log");
-	if (!_filepath.FileExists() || !_filepath.isValidPath()) {
+	if (!_filepath || !_filepath.FileExists()) {
 		_log->error("File does not exist or path is invalid: {}", _filepath.toString());
 		return false;
 	}
@@ -119,7 +119,7 @@ void SaveGame::LoadWorld() {
 	auto world = this->save.world();
 	for (int i = 0; i < world.entity_file_list_size(); i++) {
 		Path entity_filename = Path::GetAssetPath(world.entity_file_list(i));
-		if (entity_filename.isValidPath() && entity_filename.FileExists()) {
+		if (entity_filename && entity_filename.FileExists()) {
 			std::string json_string = LoadAsString(entity_filename);
 			proto::Entity entity;
 			auto status = google::protobuf::util::JsonStringToMessage(json_string, &entity);

--- a/server/save-game.cpp
+++ b/server/save-game.cpp
@@ -39,9 +39,9 @@ bool UserList::RemoveUser(uid id) {
 
 bool UserList::HasUser(uid id) { return this->GetUserItr(id) != this->users.end(); }
 
-bool SaveGame::Load(std::string _filename) { return this->Load(FilePath(_filename)); }
+bool SaveGame::Load(std::string _filename) { return this->Load(Path(_filename)); }
 
-bool SaveGame::Load(const FilePath _filepath) {
+bool SaveGame::Load(const Path _filepath) {
 	auto _log = spdlog::get("console_log");
 	this->filepath = _filepath;
 	if (!_filepath.FileExists()) {
@@ -62,11 +62,11 @@ bool SaveGame::Load(const FilePath _filepath) {
 
 bool SaveGame::Reload() { return this->Load(this->filepath); }
 
-bool SaveGame::Reload(const FilePath _filepath) { return this->Load(_filepath); }
+bool SaveGame::Reload(const Path _filepath) { return this->Load(_filepath); }
 
 bool SaveGame::Save() { return this->Save(this->filepath); }
 
-bool SaveGame::Save(const FilePath _filepath) {
+bool SaveGame::Save(const Path _filepath) {
 	auto _log = spdlog::get("console_log");
 	if (!_filepath.FileExists() || !_filepath.isValidPath()) {
 		_log->error("File does not exist or path is invalid: {}", _filepath.toString());
@@ -118,7 +118,7 @@ void SaveGame::LoadWorld() {
 	auto _log = spdlog::get("console_log");
 	auto world = this->save.world();
 	for (int i = 0; i < world.entity_file_list_size(); i++) {
-		FilePath entity_filename = FilePath::GetAssetPath(world.entity_file_list(i));
+		Path entity_filename = Path::GetAssetPath(world.entity_file_list(i));
 		if (entity_filename.isValidPath() && entity_filename.FileExists()) {
 			std::string json_string = LoadAsString(entity_filename);
 			proto::Entity entity;

--- a/server/save-game.hpp
+++ b/server/save-game.hpp
@@ -54,12 +54,12 @@ private:
 
 class SaveGame {
 public:
-	bool Load(const FilePath);
+	bool Load(const Path);
 	bool Load(std::string);
 	bool Reload();
-	bool Reload(const FilePath);
+	bool Reload(const Path);
 	bool Save();
-	bool Save(const FilePath);
+	bool Save(const Path);
 
 	UserList* GetUserList();
 
@@ -72,7 +72,7 @@ private:
 	void SaveWorld();
 
 	proto::SaveGame save;
-	FilePath filepath;
+	Path filepath;
 	UserList user_list;
 };
 } // namespace tec

--- a/tests/save-game_test.cpp
+++ b/tests/save-game_test.cpp
@@ -1,4 +1,3 @@
-#include <filesystem>
 #include <fstream>
 #include <gtest/gtest.h>
 
@@ -24,10 +23,13 @@ protected:
 
 	void TearDown() override {
 		try {
-			//std::filesystem::remove_all(save_directory.GetNativePath());
+			Path::Listing(save_directory);
+			size_t n = Path::RemoveAll(save_directory);
+			EXPECT_EQ(n, 2);
+			Path::Listing(save_directory);
 		}
-		catch (std::filesystem::filesystem_error err) {
-			std::cout << "Failed to clean up - " << err.code() << ":" << err.what() << std::endl;
+		catch (tec::PathException& err) {
+			std::cout << "Failed to clean up:" << err.what() << std::endl;
 		}
 	}
 };

--- a/tests/save-game_test.cpp
+++ b/tests/save-game_test.cpp
@@ -6,8 +6,8 @@
 
 using namespace tec;
 
-const FilePath save_directory = FilePath::GetAssetPath("save_test_123456");
-const FilePath save_file_path = save_directory + "/save.json";
+const Path save_directory = Path::GetAssetPath("save_test_123456");
+const Path save_file_path = save_directory / "save.json";
 const std::string
 		contents("{\"users\":[{\"id\":\"user-1\",\"username\":\"John\"}], \"world\":{\"entityFileList\":[]}}");
 const eid entity_id = 1234;
@@ -15,7 +15,7 @@ const eid entity_id = 1234;
 class SaveGameTest : public ::testing::Test {
 protected:
 	void SetUp() override {
-		ASSERT_TRUE(FilePath::MkDir(save_directory)) << "save_directory: " << save_directory.toString();
+		ASSERT_TRUE(Path::MkDir(save_directory)) << "save_directory: " << save_directory.toString();
 		std::fstream output(save_file_path.GetNativePath(), std::ios::out);
 		ASSERT_TRUE(output.good());
 		output.write(contents.c_str(), contents.length());
@@ -24,7 +24,7 @@ protected:
 
 	void TearDown() override {
 		try {
-			std::filesystem::remove_all(save_directory.toString());
+			//std::filesystem::remove_all(save_directory.GetNativePath());
 		}
 		catch (std::filesystem::filesystem_error err) {
 			std::cout << "Failed to clean up - " << err.code() << ":" << err.what() << std::endl;


### PR DESCRIPTION
## Description
- FilePath was renamed to Path, because Paths are so much more than just files.
Added "root devices" to the API, at least in concept, these work like drives in Windows or a schema in a URL,
- The only supported root devices are Windows drive letters or the `assets:` pseudo root.
- Path can open files and return streams and everything was made to use it.
- This is considered a breaking change because the Path API has different semantics.
- The new Path API is always in a generic normalized form and will now raise exceptions in many cases.
- There are a few other minor details as pointed out in commit messages

## Motivation and Context
Originally, I just wanted a method to get the stem of a filename, but then I started rewriting so much more.
Some of these changes will help support #148 where things now open files through the Path API
and #115 is partially done (OS specific stuff separate from generic, but it's not per OS).
I considered using more of the std::filesystem API, but I would still have to write a bunch of wrappers and path logic for a VFS later.
Also my OS X machine seems to give me build trouble with std::filesystem, and I don't want to deal with that yet.
In general, GetNativePath shouldn't be called outside of the Path or VFS code, so I was determined to clean that up.

## How Has This Been Tested?
The tests executable was run on Windows, Linux, and Mac OS X
The client and server were tested on Windows and Linux
Many new test cases where added and others changed or fixed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
