### PR TITLE
Render system code quality cleanup

### DIFF
--- a/client/graphics/animation.hpp
+++ b/client/graphics/animation.hpp
@@ -49,6 +49,10 @@ public:
 	void Out(proto::Component* target);
 	void In(const proto::Component& source);
 
+	bool HasBoneTransforms() const { return !bone_transforms.empty(); }
+
+	const auto& GetBoneTransforms() { return this->bone_transforms; }
+
 	friend class RenderSystem;
 
 private:

--- a/client/graphics/gbuffer.cpp
+++ b/client/graphics/gbuffer.cpp
@@ -96,7 +96,7 @@ void GBuffer::StencilPass() {
 	glStencilOpSeparate(GL_FRONT, GL_KEEP, GL_DECR_WRAP, GL_KEEP);
 }
 
-void GBuffer::BeginLightPass() {
+void GBuffer::BeginLightPass() const {
 	glDrawBuffer(GL_COLOR_ATTACHMENT4);
 	glDisable(GL_DEPTH_TEST);
 	glEnable(GL_CULL_FACE);
@@ -111,11 +111,11 @@ void GBuffer::BeginLightPass() {
 	}
 }
 
-void GBuffer::BeginDirLightPass() { glStencilFunc(GL_ALWAYS, 0, 0); }
+void GBuffer::BeginDirLightPass() const { glStencilFunc(GL_ALWAYS, 0, 0); }
 
-void GBuffer::BeginPointLightPass() {}
+void GBuffer::BeginPointLightPass() const {}
 
-void GBuffer::EndPointLightPass() {
+void GBuffer::EndPointLightPass() const {
 	// glDisable(GL_BLEND);
 }
 

--- a/client/graphics/gbuffer.cpp
+++ b/client/graphics/gbuffer.cpp
@@ -96,7 +96,7 @@ void GBuffer::StencilPass() {
 	glStencilOpSeparate(GL_FRONT, GL_KEEP, GL_DECR_WRAP, GL_KEEP);
 }
 
-void GBuffer::BeginLightPass() const {
+void GBuffer::BeginLightPass() {
 	glDrawBuffer(GL_COLOR_ATTACHMENT4);
 	glDisable(GL_DEPTH_TEST);
 	glEnable(GL_CULL_FACE);
@@ -111,7 +111,7 @@ void GBuffer::BeginLightPass() const {
 	}
 }
 
-void GBuffer::BeginDirLightPass() const { glStencilFunc(GL_ALWAYS, 0, 0); }
+void GBuffer::BeginDirLightPass() { glStencilFunc(GL_ALWAYS, 0, 0); }
 
 void GBuffer::BeginPointLightPass() const {}
 
@@ -119,7 +119,7 @@ void GBuffer::EndPointLightPass() const {
 	// glDisable(GL_BLEND);
 }
 
-void GBuffer::FinalPass() const {
+void GBuffer::FinalPass() {
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
 	this->BindForRendering();
 	glReadBuffer(GL_COLOR_ATTACHMENT4);

--- a/client/graphics/gbuffer.hpp
+++ b/client/graphics/gbuffer.hpp
@@ -30,12 +30,12 @@ public:
 
 	static void StencilPass();
 
-	void BeginLightPass();
+	void BeginLightPass() const;
 
-	void BeginDirLightPass();
+	void BeginDirLightPass() const;
 
-	void BeginPointLightPass();
-	void EndPointLightPass();
+	void BeginPointLightPass() const;
+	void EndPointLightPass() const;
 
 	void FinalPass() const;
 

--- a/client/graphics/gbuffer.hpp
+++ b/client/graphics/gbuffer.hpp
@@ -30,14 +30,14 @@ public:
 
 	static void StencilPass();
 
-	void BeginLightPass() const;
+	void BeginLightPass();
 
-	void BeginDirLightPass() const;
+	void BeginDirLightPass();
 
 	void BeginPointLightPass() const;
 	void EndPointLightPass() const;
 
-	void FinalPass() const;
+	void FinalPass();
 
 	void BindForWriting() const;
 	void BindForRendering() const;

--- a/client/graphics/gl-symbol.hpp
+++ b/client/graphics/gl-symbol.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <fmt/core.h>
+#include <forward_list>
+#include <map>
+
+namespace tec::graphics {
+
+class GLSymbol {
+public:
+	static const GLSymbol& Get(GLenum which) {
+		static const std::map<GLenum, GLSymbol> symbolic_gl_types{
+				// error codes
+				{GL_NO_ERROR, {"GL_NO_ERROR"}},
+				{GL_INVALID_ENUM, {"GL_INVALID_ENUM"}},
+				{GL_INVALID_VALUE, {"GL_INVALID_VALUE"}},
+				{GL_INVALID_OPERATION, {"GL_INVALID_OPERATION"}},
+				{GL_INVALID_FRAMEBUFFER_OPERATION, {"GL_INVALID_FRAMEBUFFER_OPERATION"}},
+				{GL_OUT_OF_MEMORY, {"GL_OUT_OF_MEMORY"}},
+				// image formats
+				{GL_DEPTH_COMPONENT, {"GL_DEPTH_COMPONENT"}},
+				{GL_DEPTH_STENCIL, {"GL_DEPTH_STENCIL"}},
+				{GL_RED, {"GL_RED"}},
+				{GL_RG, {"GL_RG"}},
+				{GL_RGB, {"GL_RGB"}},
+				{GL_RGBA, {"GL_RGBA"}},
+				{GL_SRGB, {"GL_SRGB"}},
+				{GL_SRGB_ALPHA, {"GL_SRGB_ALPHA"}},
+				{GL_SRGB8_ALPHA8, {"GL_SRGB8_ALPHA8"}},
+				// shader types
+				{GL_FLOAT, {"float"}},
+				{GL_FLOAT_VEC2, {"vec2"}},
+				{GL_FLOAT_VEC3, {"vec3"}},
+				{GL_FLOAT_VEC4, {"vec4"}},
+				{GL_INT, {"int"}},
+				{GL_INT_VEC2, {"ivec2"}},
+				{GL_INT_VEC3, {"ivec3"}},
+				{GL_INT_VEC4, {"ivec4"}},
+				{GL_SAMPLER_1D, {"sampler1D"}},
+				{GL_SAMPLER_2D, {"sampler2D"}},
+				{GL_SAMPLER_3D, {"sampler3D"}},
+				{GL_SAMPLER_2D_SHADOW, {"sampler2DShadow"}},
+				{GL_SAMPLER_CUBE_SHADOW, {"samplerCubeShadow"}},
+				{GL_SAMPLER_2D_ARRAY, {"sampler2DArray"}},
+				{GL_UNSIGNED_INT, {"uint"}},
+				{GL_FLOAT_MAT4, {"mat4x4"}},
+		};
+		static std::forward_list<std::string> unknown_gl_strings;
+		static std::map<GLenum, GLSymbol> unknown_gl_types;
+		if (const auto sym_itr = symbolic_gl_types.find(which); sym_itr != symbolic_gl_types.cend()) {
+			return sym_itr->second;
+		}
+		unknown_gl_strings.push_front(std::to_string(which));
+		return unknown_gl_types.emplace(std::make_pair(which, GLSymbol{unknown_gl_strings.front()})).first->second;
+	}
+	std::string name;
+};
+} // namespace tec::graphics
+
+template <> struct fmt::formatter<tec::graphics::GLSymbol> {
+	static constexpr auto parse(const format_parse_context& ctx) -> decltype(ctx.begin()) {
+		const auto it = ctx.begin();
+		if (const auto end = ctx.end(); it != end && *it != '}')
+			throw std::runtime_error("invalid format");
+		return it;
+	}
+	template <typename FormatContext>
+	static auto format(const tec::graphics::GLSymbol& p, FormatContext& ctx) -> decltype(ctx.out()) {
+		return fmt::format_to(ctx.out(), "{}", p.name);
+	}
+};

--- a/client/graphics/passes/debug-pass.hpp
+++ b/client/graphics/passes/debug-pass.hpp
@@ -23,14 +23,14 @@ public:
 
 		const auto& quad_vbo = RenderSystem::quad_vbo;
 
-		glBindVertexArray(quad_vbo.GetVAO());
+		glBindVertexArray(quad_vbo->GetVAO());
 
 		const std::shared_ptr<Shader> def_db_shader = ShaderMap::Get(default_shaders.gbufdebug());
 		def_db_shader->Use();
 
 		glUniform2f(def_db_shader->GetUniformLocation("gScreenSize"), this->inv_view_size.x, this->inv_view_size.y);
 
-		const auto index_count{static_cast<GLsizei>(quad_vbo.GetVertexGroupIndexCount(0))};
+		const auto index_count{static_cast<GLsizei>(quad_vbo->GetVertexGroupIndexCount(0))};
 		glDrawElements(GL_TRIANGLES, index_count, GL_UNSIGNED_INT, nullptr);
 
 		def_db_shader->UnUse();

--- a/client/graphics/passes/debug-pass.hpp
+++ b/client/graphics/passes/debug-pass.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "render-pass.hpp"
+#include "resources/obj.hpp"
+
+#include <memory>
+
+namespace tec::graphics::pass {
+
+class DebugPass final : public RenderPass {
+public:
+	DebugPass() : RenderPass("DebugPass") {}
+	void Prepare(const GBuffer& gbuffer) override {
+		gbuffer.BindForRendering();
+		glActiveTexture(GL_TEXTURE0 + static_cast<int>(GBuffer::DEPTH_TYPE::DEPTH));
+		glBindSampler(static_cast<int>(GBuffer::DEPTH_TYPE::DEPTH), 0);
+		glBindTexture(GL_TEXTURE_2D, gbuffer.GetDepthTexture());
+	}
+	void Run(const gfx::ShaderSet& default_shaders, const View&, const RenderItems&) override {
+		glDisable(GL_BLEND);
+		glDrawBuffer(GL_BACK);
+		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+
+		const auto& quad_vbo = RenderSystem::quad_vbo;
+
+		glBindVertexArray(quad_vbo.GetVAO());
+
+		const std::shared_ptr<Shader> def_db_shader = ShaderMap::Get(default_shaders.gbufdebug());
+		def_db_shader->Use();
+
+		glUniform2f(def_db_shader->GetUniformLocation("gScreenSize"), this->inv_view_size.x, this->inv_view_size.y);
+
+		const auto index_count{static_cast<GLsizei>(quad_vbo.GetVertexGroupIndexCount(0))};
+		glDrawElements(GL_TRIANGLES, index_count, GL_UNSIGNED_INT, nullptr);
+
+		def_db_shader->UnUse();
+		glBindVertexArray(0);
+	}
+	void Complete(const GBuffer&) override {}
+};
+} // namespace tec::graphics::pass

--- a/client/graphics/passes/debug-pass.hpp
+++ b/client/graphics/passes/debug-pass.hpp
@@ -10,13 +10,14 @@ namespace tec::graphics::pass {
 class DebugPass final : public RenderPass {
 public:
 	DebugPass() : RenderPass("DebugPass") {}
-	void Prepare(const GBuffer& gbuffer) override {
+	void Prepare(GBuffer& gbuffer) override {
 		gbuffer.BindForRendering();
 		glActiveTexture(GL_TEXTURE0 + static_cast<int>(GBuffer::DEPTH_TYPE::DEPTH));
 		glBindSampler(static_cast<int>(GBuffer::DEPTH_TYPE::DEPTH), 0);
 		glBindTexture(GL_TEXTURE_2D, gbuffer.GetDepthTexture());
 	}
-	void Run(const gfx::ShaderSet& default_shaders, const View&, const RenderItems&) override {
+	void
+	Run(const gfx::ShaderSet& default_shaders, const Viewport& viewport, const View&, const RenderItems&) override {
 		glDisable(GL_BLEND);
 		glDrawBuffer(GL_BACK);
 		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
@@ -28,7 +29,8 @@ public:
 		const std::shared_ptr<Shader> def_db_shader = ShaderMap::Get(default_shaders.gbufdebug());
 		def_db_shader->Use();
 
-		glUniform2f(def_db_shader->GetUniformLocation("gScreenSize"), this->inv_view_size.x, this->inv_view_size.y);
+		glUniform2f(
+				def_db_shader->GetUniformLocation("gScreenSize"), viewport.inv_view_size.x, viewport.inv_view_size.y);
 
 		const auto index_count{static_cast<GLsizei>(quad_vbo->GetVertexGroupIndexCount(0))};
 		glDrawElements(GL_TRIANGLES, index_count, GL_UNSIGNED_INT, nullptr);
@@ -36,6 +38,6 @@ public:
 		def_db_shader->UnUse();
 		glBindVertexArray(0);
 	}
-	void Complete(const GBuffer&) override {}
+	void Complete(GBuffer&) override {}
 };
 } // namespace tec::graphics::pass

--- a/client/graphics/passes/debug-pass.hpp
+++ b/client/graphics/passes/debug-pass.hpp
@@ -16,8 +16,7 @@ public:
 		glBindSampler(static_cast<int>(GBuffer::DEPTH_TYPE::DEPTH), 0);
 		glBindTexture(GL_TEXTURE_2D, gbuffer.GetDepthTexture());
 	}
-	void
-	Run(const gfx::ShaderSet& default_shaders, const Viewport& viewport, const View&, const RenderItems&) override {
+	void Run(const gfx::ShaderSet& shaders, const Viewport& viewport, const View&, const RenderItems&) override {
 		glDisable(GL_BLEND);
 		glDrawBuffer(GL_BACK);
 		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
@@ -26,7 +25,7 @@ public:
 
 		glBindVertexArray(quad_vbo->GetVAO());
 
-		const std::shared_ptr<Shader> def_db_shader = ShaderMap::Get(default_shaders.gbufdebug());
+		const std::shared_ptr<Shader> def_db_shader = ShaderMap::Get(shaders.gbufdebug());
 		def_db_shader->Use();
 
 		glUniform2f(

--- a/client/graphics/passes/dir-light-pass.hpp
+++ b/client/graphics/passes/dir-light-pass.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "render-pass.hpp"
+#include "resources/obj.hpp"
+
+#include <memory>
+
+namespace tec::graphics::pass {
+using DirectionalLightMap = Multiton<eid, DirectionalLight*>;
+
+class DirLightPass final : public RenderPass {
+public:
+	DirLightPass() : RenderPass("DirLightPass"){}
+	void Prepare(const GBuffer& gbuffer) override { gbuffer.BeginDirLightPass(); }
+	void Run(const gfx::ShaderSet& default_shaders, const View& view, const RenderItems&) override {
+		const std::shared_ptr<Shader> def_dl_shader = ShaderMap::Get(default_shaders.dirlight());
+		def_dl_shader->Use();
+		
+		glUniform2f(def_dl_shader->GetUniformLocation("gScreenSize"), this->inv_view_size.x, this->inv_view_size.y);
+		glUniform3fv(def_dl_shader->GetUniformLocation("view_pos"), 1, glm::value_ptr(view.view_pos));
+		const GLint color_index = def_dl_shader->GetUniformLocation("gDirectionalLight.Base.Color");
+		const GLint ambient_intensity_index =
+				def_dl_shader->GetUniformLocation("gDirectionalLight.Base.AmbientIntensity");
+		const GLint diffuse_intensity_index =
+				def_dl_shader->GetUniformLocation("gDirectionalLight.Base.DiffuseIntensity");
+		const GLint direction_index = def_dl_shader->GetUniformLocation("gDirectionalLight.Direction");
+
+		const auto& quad_vbo = RenderSystem::quad_vbo;
+
+		glBindVertexArray(quad_vbo.GetVAO());
+
+		const auto index_count{static_cast<GLsizei>(quad_vbo.GetVertexGroupIndexCount(0))};
+
+		for (auto itr = DirectionalLightMap::Begin(); itr != DirectionalLightMap::End(); ++itr) {
+			const DirectionalLight* light = itr->second;
+
+			glUniform3f(color_index, light->color.x, light->color.y, light->color.z);
+			glUniform1f(ambient_intensity_index, light->ambient_intensity);
+			glUniform1f(diffuse_intensity_index, light->diffuse_intensity);
+			glUniform3f(direction_index, light->direction.x, light->direction.y, light->direction.z);
+
+			glDrawElements(GL_TRIANGLES, index_count, GL_UNSIGNED_INT, nullptr);
+		}
+		def_dl_shader->UnUse();
+		glBindVertexArray(0);
+	}
+	void Complete(const GBuffer& gbuffer) override { gbuffer.EndPointLightPass(); }
+};
+} // namespace tec::graphics::pass

--- a/client/graphics/passes/dir-light-pass.hpp
+++ b/client/graphics/passes/dir-light-pass.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "render-pass.hpp"
-#include "resources/obj.hpp"
 
 #include <memory>
 
@@ -27,9 +26,9 @@ public:
 
 		const auto& quad_vbo = RenderSystem::quad_vbo;
 
-		glBindVertexArray(quad_vbo.GetVAO());
+		glBindVertexArray(quad_vbo->GetVAO());
 
-		const auto index_count{static_cast<GLsizei>(quad_vbo.GetVertexGroupIndexCount(0))};
+		const auto index_count{static_cast<GLsizei>(quad_vbo->GetVertexGroupIndexCount(0))};
 
 		for (auto itr = DirectionalLightMap::Begin(); itr != DirectionalLightMap::End(); ++itr) {
 			const DirectionalLight* light = itr->second;

--- a/client/graphics/passes/dir-light-pass.hpp
+++ b/client/graphics/passes/dir-light-pass.hpp
@@ -9,13 +9,15 @@ using DirectionalLightMap = Multiton<eid, DirectionalLight*>;
 
 class DirLightPass final : public RenderPass {
 public:
-	DirLightPass() : RenderPass("DirLightPass"){}
-	void Prepare(const GBuffer& gbuffer) override { gbuffer.BeginDirLightPass(); }
-	void Run(const gfx::ShaderSet& default_shaders, const View& view, const RenderItems&) override {
+	DirLightPass() : RenderPass("DirLightPass") {}
+	void Prepare(GBuffer& gbuffer) override { gbuffer.BeginDirLightPass(); }
+	void Run(const gfx::ShaderSet& default_shaders, const Viewport& viewport, const View& view, const RenderItems&)
+			override {
 		const std::shared_ptr<Shader> def_dl_shader = ShaderMap::Get(default_shaders.dirlight());
 		def_dl_shader->Use();
-		
-		glUniform2f(def_dl_shader->GetUniformLocation("gScreenSize"), this->inv_view_size.x, this->inv_view_size.y);
+
+		glUniform2f(
+				def_dl_shader->GetUniformLocation("gScreenSize"), viewport.inv_view_size.x, viewport.inv_view_size.y);
 		glUniform3fv(def_dl_shader->GetUniformLocation("view_pos"), 1, glm::value_ptr(view.view_pos));
 		const GLint color_index = def_dl_shader->GetUniformLocation("gDirectionalLight.Base.Color");
 		const GLint ambient_intensity_index =
@@ -43,6 +45,6 @@ public:
 		def_dl_shader->UnUse();
 		glBindVertexArray(0);
 	}
-	void Complete(const GBuffer& gbuffer) override { gbuffer.EndPointLightPass(); }
+	void Complete(GBuffer& gbuffer) override { gbuffer.EndPointLightPass(); }
 };
 } // namespace tec::graphics::pass

--- a/client/graphics/passes/dir-light-pass.hpp
+++ b/client/graphics/passes/dir-light-pass.hpp
@@ -11,9 +11,8 @@ class DirLightPass final : public RenderPass {
 public:
 	DirLightPass() : RenderPass("DirLightPass") {}
 	void Prepare(GBuffer& gbuffer) override { gbuffer.BeginDirLightPass(); }
-	void Run(const gfx::ShaderSet& default_shaders, const Viewport& viewport, const View& view, const RenderItems&)
-			override {
-		const std::shared_ptr<Shader> def_dl_shader = ShaderMap::Get(default_shaders.dirlight());
+	void Run(const gfx::ShaderSet& shaders, const Viewport& viewport, const View& view, const RenderItems&) override {
+		const std::shared_ptr<Shader> def_dl_shader = ShaderMap::Get(shaders.dirlight());
 		def_dl_shader->Use();
 
 		glUniform2f(

--- a/client/graphics/passes/final-pass.hpp
+++ b/client/graphics/passes/final-pass.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "render-pass.hpp"
-#include "resources/obj.hpp"
 
 #include <memory>
 
@@ -19,8 +18,8 @@ public:
 
 		const auto& quad_vbo = RenderSystem::quad_vbo;
 
-		glBindVertexArray(quad_vbo.GetVAO());
-		const auto index_count{static_cast<GLsizei>(quad_vbo.GetVertexGroupIndexCount(0))};
+		glBindVertexArray(quad_vbo->GetVAO());
+		const auto index_count{static_cast<GLsizei>(quad_vbo->GetVertexGroupIndexCount(0))};
 		glDrawElements(GL_TRIANGLES, index_count, GL_UNSIGNED_INT, nullptr);
 		glBindVertexArray(0);
 

--- a/client/graphics/passes/final-pass.hpp
+++ b/client/graphics/passes/final-pass.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "render-pass.hpp"
+#include "resources/obj.hpp"
+
+#include <memory>
+
+namespace tec::graphics::pass {
+
+class FinalPass final : public RenderPass {
+public:
+	FinalPass() : RenderPass("FinalPass") {}
+	void Prepare(const GBuffer& gbuffer) override { gbuffer.FinalPass(); }
+	void Run(const gfx::ShaderSet& default_shaders, const View&, const RenderItems&) override {
+		const std::shared_ptr<Shader> post_shader = ShaderMap::Get(default_shaders.postprocess());
+
+		post_shader->Use();
+		glUniform2f(post_shader->GetUniformLocation("gScreenSize"), this->inv_view_size.x, this->inv_view_size.y);
+
+		const auto& quad_vbo = RenderSystem::quad_vbo;
+
+		glBindVertexArray(quad_vbo.GetVAO());
+		const auto index_count{static_cast<GLsizei>(quad_vbo.GetVertexGroupIndexCount(0))};
+		glDrawElements(GL_TRIANGLES, index_count, GL_UNSIGNED_INT, nullptr);
+		glBindVertexArray(0);
+
+		post_shader->UnUse();
+	}
+	void Complete(const GBuffer&) override { }
+};
+} // namespace tec::graphics::pass

--- a/client/graphics/passes/final-pass.hpp
+++ b/client/graphics/passes/final-pass.hpp
@@ -10,9 +10,8 @@ class FinalPass final : public RenderPass {
 public:
 	FinalPass() : RenderPass("FinalPass") {}
 	void Prepare(GBuffer& gbuffer) override { gbuffer.FinalPass(); }
-	void
-	Run(const gfx::ShaderSet& default_shaders, const Viewport& viewport, const View&, const RenderItems&) override {
-		const std::shared_ptr<Shader> post_shader = ShaderMap::Get(default_shaders.postprocess());
+	void Run(const gfx::ShaderSet& shaders, const Viewport& viewport, const View&, const RenderItems&) override {
+		const std::shared_ptr<Shader> post_shader = ShaderMap::Get(shaders.postprocess());
 
 		post_shader->Use();
 		glUniform2f(post_shader->GetUniformLocation("gScreenSize"), viewport.inv_view_size.x, viewport.inv_view_size.y);

--- a/client/graphics/passes/final-pass.hpp
+++ b/client/graphics/passes/final-pass.hpp
@@ -9,12 +9,13 @@ namespace tec::graphics::pass {
 class FinalPass final : public RenderPass {
 public:
 	FinalPass() : RenderPass("FinalPass") {}
-	void Prepare(const GBuffer& gbuffer) override { gbuffer.FinalPass(); }
-	void Run(const gfx::ShaderSet& default_shaders, const View&, const RenderItems&) override {
+	void Prepare(GBuffer& gbuffer) override { gbuffer.FinalPass(); }
+	void
+	Run(const gfx::ShaderSet& default_shaders, const Viewport& viewport, const View&, const RenderItems&) override {
 		const std::shared_ptr<Shader> post_shader = ShaderMap::Get(default_shaders.postprocess());
 
 		post_shader->Use();
-		glUniform2f(post_shader->GetUniformLocation("gScreenSize"), this->inv_view_size.x, this->inv_view_size.y);
+		glUniform2f(post_shader->GetUniformLocation("gScreenSize"), viewport.inv_view_size.x, viewport.inv_view_size.y);
 
 		const auto& quad_vbo = RenderSystem::quad_vbo;
 
@@ -25,6 +26,6 @@ public:
 
 		post_shader->UnUse();
 	}
-	void Complete(const GBuffer&) override { }
+	void Complete(GBuffer&) override {}
 };
 } // namespace tec::graphics::pass

--- a/client/graphics/passes/geometry-pass.hpp
+++ b/client/graphics/passes/geometry-pass.hpp
@@ -1,0 +1,103 @@
+#pragma once
+
+#include "graphics/texture-object.hpp"
+#include "render-pass.hpp"
+
+#include <memory>
+
+namespace tec::graphics::pass {
+struct UniformLocations {
+	GLint model_pos;
+	GLint model_scale;
+	GLint model_quat;
+	GLint bones;
+	GLint animated;
+	GLint vertex_group;
+};
+
+class GeometryPass final : public RenderPass {
+public:
+	GeometryPass() : RenderPass("GeometryPass") {}
+	void Prepare(const GBuffer& gbuffer) override { gbuffer.BeginGeometryPass(); }
+	void Run(const gfx::ShaderSet& default_shaders, const View& view, const RenderItems& render_items) override {
+		const GLuint def_textures[]{TextureMap::Get("default")->GetID(), TextureMap::Get("default_sp")->GetID()};
+
+		glActiveTexture(GL_TEXTURE0);
+		glBindTexture(GL_TEXTURE_2D, def_textures[0]);
+		glActiveTexture(GL_TEXTURE1);
+		glBindTexture(GL_TEXTURE_2D, def_textures[1]);
+
+		const std::shared_ptr<Shader> def_shader = ShaderMap::Get(default_shaders.visual());
+		def_shader->Use();
+
+		glUniform3fv(def_shader->GetUniformLocation("view_pos"), 1, glm::value_ptr(view.view_pos));
+		glUniform4fv(def_shader->GetUniformLocation("view_quat"), 1, glm::value_ptr(view.view_quat));
+		glUniformMatrix4fv(def_shader->GetUniformLocation("projection"), 1, GL_FALSE, glm::value_ptr(this->projection));
+		const UniformLocations default_shader_locations{
+				def_shader->GetUniformLocation("model_position"),
+				def_shader->GetUniformLocation("model_scale"),
+				def_shader->GetUniformLocation("model_quat"),
+				def_shader->GetUniformLocation("animated"),
+				def_shader->GetUniformLocation("animation_matrix"),
+				-1};
+
+		for (auto [_shader, _render_item] : render_items) {
+			auto [model_pos, model_scale, model_quat, bones, animated, vertex_group] = default_shader_locations;
+			// Check if we need to use a specific shader and set it up.
+			if (_shader) {
+				def_shader->UnUse();
+				_shader->Use();
+				glUniform3fv(_shader->GetUniformLocation("view_pos"), 1, glm::value_ptr(view.view_pos));
+				glUniform4fv(_shader->GetUniformLocation("view_quat"), 1, glm::value_ptr(view.view_quat));
+				glUniformMatrix4fv(
+						_shader->GetUniformLocation("projection"), 1, GL_FALSE, glm::value_ptr(this->projection));
+				model_pos = _shader->GetUniformLocation("model_position");
+				model_scale = _shader->GetUniformLocation("model_scale");
+				model_quat = _shader->GetUniformLocation("model_quat");
+				bones = _shader->GetUniformLocation("animation_bones[0]");
+				animated = _shader->GetUniformLocation("animated");
+				vertex_group = _shader->GetUniformLocation("vertex_group");
+			}
+			for (const auto render_item : _render_item) {
+				glBindVertexArray(render_item->vbo->GetVAO());
+				glUniform1i(animated, render_item->animated ? 1 : 0);
+
+				if (render_item->animated && bones != -1) {
+					auto& bone_transforms = render_item->animation->GetBoneTransforms();
+					glUniformMatrix3x4fv(
+							bones,
+							static_cast<int>(bone_transforms.size()),
+							GL_FALSE,
+							glm::value_ptr(bone_transforms[0].orientation));
+				}
+				GLint vertex_group_number = 0;
+				for (auto& [material, mesh_group_number, index_count, starting_offset] : render_item->vertex_groups) {
+					glPolygonMode(GL_FRONT_AND_BACK, material->GetPolygonMode());
+					RenderSystem::ActivateMaterial(*material);
+					if (vertex_group != -1) {
+						glUniform1i(vertex_group, vertex_group_number++);
+					}
+					//glUniformMatrix4fv(model_index, 1, GL_FALSE, glm::value_ptr(render_item->model_matrix));
+					glUniform3fv(model_pos, 1, glm::value_ptr(render_item->model_position));
+					glUniform3fv(model_scale, 1, glm::value_ptr(render_item->model_scale));
+					glUniform4fv(model_quat, 1, glm::value_ptr(render_item->model_quat));
+					glDrawElements(
+							material->GetDrawElementsMode(),
+							static_cast<GLsizei>(index_count),
+							GL_UNSIGNED_INT,
+							reinterpret_cast<GLvoid*>(starting_offset * sizeof(GLuint)));
+					RenderSystem::DeactivateMaterial(*material, def_textures);
+				}
+			}
+			// If we used a special shader set things back to the deferred shader.
+			if (_shader) {
+				_shader->UnUse();
+				def_shader->Use();
+			}
+		}
+		def_shader->UnUse();
+		glBindVertexArray(0);
+	}
+	void Complete(const GBuffer& gbuffer) override { gbuffer.EndGeometryPass(); }
+};
+} // namespace tec::graphics::pass

--- a/client/graphics/passes/geometry-pass.hpp
+++ b/client/graphics/passes/geometry-pass.hpp
@@ -19,11 +19,8 @@ class GeometryPass final : public RenderPass {
 public:
 	GeometryPass() : RenderPass("GeometryPass") {}
 	void Prepare(GBuffer& gbuffer) override { gbuffer.BeginGeometryPass(); }
-	void
-	Run(const gfx::ShaderSet& default_shaders,
-		const Viewport& viewport,
-		const View& view,
-		const RenderItems& render_items) override {
+	void Run(const gfx::ShaderSet& shaders, const Viewport& viewport, const View& view, const RenderItems& render_items)
+			override {
 		const GLuint def_textures[]{TextureMap::Get("default")->GetID(), TextureMap::Get("default_sp")->GetID()};
 
 		glActiveTexture(GL_TEXTURE0);
@@ -31,7 +28,7 @@ public:
 		glActiveTexture(GL_TEXTURE1);
 		glBindTexture(GL_TEXTURE_2D, def_textures[1]);
 
-		const std::shared_ptr<Shader> def_shader = ShaderMap::Get(default_shaders.visual());
+		const std::shared_ptr<Shader> def_shader = ShaderMap::Get(shaders.visual());
 		def_shader->Use();
 
 		glUniform3fv(def_shader->GetUniformLocation("view_pos"), 1, glm::value_ptr(view.view_pos));

--- a/client/graphics/passes/geometry-pass.hpp
+++ b/client/graphics/passes/geometry-pass.hpp
@@ -18,8 +18,12 @@ struct UniformLocations {
 class GeometryPass final : public RenderPass {
 public:
 	GeometryPass() : RenderPass("GeometryPass") {}
-	void Prepare(const GBuffer& gbuffer) override { gbuffer.BeginGeometryPass(); }
-	void Run(const gfx::ShaderSet& default_shaders, const View& view, const RenderItems& render_items) override {
+	void Prepare(GBuffer& gbuffer) override { gbuffer.BeginGeometryPass(); }
+	void
+	Run(const gfx::ShaderSet& default_shaders,
+		const Viewport& viewport,
+		const View& view,
+		const RenderItems& render_items) override {
 		const GLuint def_textures[]{TextureMap::Get("default")->GetID(), TextureMap::Get("default_sp")->GetID()};
 
 		glActiveTexture(GL_TEXTURE0);
@@ -32,7 +36,8 @@ public:
 
 		glUniform3fv(def_shader->GetUniformLocation("view_pos"), 1, glm::value_ptr(view.view_pos));
 		glUniform4fv(def_shader->GetUniformLocation("view_quat"), 1, glm::value_ptr(view.view_quat));
-		glUniformMatrix4fv(def_shader->GetUniformLocation("projection"), 1, GL_FALSE, glm::value_ptr(this->projection));
+		glUniformMatrix4fv(
+				def_shader->GetUniformLocation("projection"), 1, GL_FALSE, glm::value_ptr(viewport.projection));
 		const UniformLocations default_shader_locations{
 				def_shader->GetUniformLocation("model_position"),
 				def_shader->GetUniformLocation("model_scale"),
@@ -50,7 +55,7 @@ public:
 				glUniform3fv(_shader->GetUniformLocation("view_pos"), 1, glm::value_ptr(view.view_pos));
 				glUniform4fv(_shader->GetUniformLocation("view_quat"), 1, glm::value_ptr(view.view_quat));
 				glUniformMatrix4fv(
-						_shader->GetUniformLocation("projection"), 1, GL_FALSE, glm::value_ptr(this->projection));
+						_shader->GetUniformLocation("projection"), 1, GL_FALSE, glm::value_ptr(viewport.projection));
 				model_pos = _shader->GetUniformLocation("model_position");
 				model_scale = _shader->GetUniformLocation("model_scale");
 				model_quat = _shader->GetUniformLocation("model_quat");
@@ -98,6 +103,6 @@ public:
 		def_shader->UnUse();
 		glBindVertexArray(0);
 	}
-	void Complete(const GBuffer& gbuffer) override { gbuffer.EndGeometryPass(); }
+	void Complete(GBuffer& gbuffer) override { gbuffer.EndGeometryPass(); }
 };
 } // namespace tec::graphics::pass

--- a/client/graphics/passes/point-light-pass.hpp
+++ b/client/graphics/passes/point-light-pass.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+#include "render-pass.hpp"
+#include "resources/obj.hpp"
+
+#include <memory>
+
+namespace tec::graphics::pass {
+using PointLightMap = Multiton<eid, PointLight*>;
+
+class PointLightPass final : public RenderPass {
+public:
+	PointLightPass() : RenderPass("PointLightPass") {
+		if (const auto sphere = OBJ::Create(Path("assets:/sphere/sphere.obj")); !sphere) {
+			spdlog::get("console_log")->debug("[RenderSystem] Error loading sphere.obj.");
+		}
+		else {
+			this->sphere_vbo.Load(sphere);
+		}
+	}
+	void Prepare(const GBuffer& gbuffer) override {
+		gbuffer.BeginLightPass();
+		gbuffer.BeginPointLightPass();
+	}
+	void Run(const gfx::ShaderSet& default_shaders, const View& view, const RenderItems&) override {
+		const std::shared_ptr<Shader> def_pl_shader = ShaderMap::Get(default_shaders.pointlight());
+
+		def_pl_shader->Use();
+		glUniform3fv(def_pl_shader->GetUniformLocation("view_pos"), 1, glm::value_ptr(view.view_pos));
+		glUniform4fv(def_pl_shader->GetUniformLocation("view_quat"), 1, glm::value_ptr(view.view_quat));
+		glUniformMatrix4fv(
+				def_pl_shader->GetUniformLocation("projection"), 1, GL_FALSE, glm::value_ptr(this->projection));
+		glUniform2f(def_pl_shader->GetUniformLocation("gScreenSize"), this->inv_view_size.x, this->inv_view_size.y);
+		const GLint model_index = def_pl_shader->GetUniformLocation("model");
+		const GLint color_index = def_pl_shader->GetUniformLocation("gPointLight.Base.Color");
+		const GLint ambient_intensity_index = def_pl_shader->GetUniformLocation("gPointLight.Base.AmbientIntensity");
+		const GLint diffuse_intensity_index = def_pl_shader->GetUniformLocation("gPointLight.Base.DiffuseIntensity");
+		const GLint atten_constant_index = def_pl_shader->GetUniformLocation("gPointLight.Atten.Constant");
+		const GLint atten_linear_index = def_pl_shader->GetUniformLocation("gPointLight.Atten.Linear");
+		const GLint atten_exp_index = def_pl_shader->GetUniformLocation("gPointLight.Atten.Exp");
+
+		const auto index_count{static_cast<GLsizei>(this->sphere_vbo.GetVertexGroup(0)->index_count)};
+
+		glBindVertexArray(this->sphere_vbo.GetVAO());
+		for (auto itr = PointLightMap::Begin(); itr != PointLightMap::End(); ++itr) {
+			auto& [entity_id, light] = *itr;
+
+			glm::vec3 position;
+			if (Multiton<eid, Position*>::Has(entity_id)) {
+				position = Multiton<eid, Position*>::Get(entity_id)->value;
+			}
+
+			light->UpdateBoundingRadius();
+			glm::mat4 transform_matrix =
+					glm::scale(glm::translate(glm::mat4(1.0), position), glm::vec3(light->bounding_radius));
+
+			glUniformMatrix4fv(model_index, 1, GL_FALSE, glm::value_ptr(transform_matrix));
+			glUniform3f(color_index, light->color.x, light->color.y, light->color.z);
+			glUniform1f(ambient_intensity_index, light->ambient_intensity);
+			glUniform1f(diffuse_intensity_index, light->diffuse_intensity);
+			glUniform1f(atten_constant_index, light->Attenuation.constant);
+			glUniform1f(atten_linear_index, light->Attenuation.linear);
+			glUniform1f(atten_exp_index, light->Attenuation.exponential);
+			glDrawElements(GL_TRIANGLES, index_count, GL_UNSIGNED_INT, nullptr);
+		}
+		glBindVertexArray(0);
+		def_pl_shader->UnUse();
+	}
+	void Complete(const GBuffer& gbuffer) override { gbuffer.EndPointLightPass(); }
+
+private:
+	VertexBufferObject sphere_vbo{vertex::VF_BASE};
+};
+} // namespace tec::graphics::pass

--- a/client/graphics/passes/point-light-pass.hpp
+++ b/client/graphics/passes/point-light-pass.hpp
@@ -18,19 +18,21 @@ public:
 			this->sphere_vbo.Load(sphere);
 		}
 	}
-	void Prepare(const GBuffer& gbuffer) override {
+	void Prepare(GBuffer& gbuffer) override {
 		gbuffer.BeginLightPass();
 		gbuffer.BeginPointLightPass();
 	}
-	void Run(const gfx::ShaderSet& default_shaders, const View& view, const RenderItems&) override {
+	void Run(const gfx::ShaderSet& default_shaders, const Viewport& viewport, const View& view, const RenderItems&)
+			override {
 		const std::shared_ptr<Shader> def_pl_shader = ShaderMap::Get(default_shaders.pointlight());
 
 		def_pl_shader->Use();
 		glUniform3fv(def_pl_shader->GetUniformLocation("view_pos"), 1, glm::value_ptr(view.view_pos));
 		glUniform4fv(def_pl_shader->GetUniformLocation("view_quat"), 1, glm::value_ptr(view.view_quat));
 		glUniformMatrix4fv(
-				def_pl_shader->GetUniformLocation("projection"), 1, GL_FALSE, glm::value_ptr(this->projection));
-		glUniform2f(def_pl_shader->GetUniformLocation("gScreenSize"), this->inv_view_size.x, this->inv_view_size.y);
+				def_pl_shader->GetUniformLocation("projection"), 1, GL_FALSE, glm::value_ptr(viewport.projection));
+		glUniform2f(
+				def_pl_shader->GetUniformLocation("gScreenSize"), viewport.inv_view_size.x, viewport.inv_view_size.y);
 		const GLint model_index = def_pl_shader->GetUniformLocation("model");
 		const GLint color_index = def_pl_shader->GetUniformLocation("gPointLight.Base.Color");
 		const GLint ambient_intensity_index = def_pl_shader->GetUniformLocation("gPointLight.Base.AmbientIntensity");
@@ -66,7 +68,7 @@ public:
 		glBindVertexArray(0);
 		def_pl_shader->UnUse();
 	}
-	void Complete(const GBuffer& gbuffer) override { gbuffer.EndPointLightPass(); }
+	void Complete(GBuffer& gbuffer) override { gbuffer.EndPointLightPass(); }
 
 private:
 	VertexBufferObject sphere_vbo{vertex::VF_BASE};

--- a/client/graphics/passes/render-pass.hpp
+++ b/client/graphics/passes/render-pass.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "graphics/gbuffer.hpp"
+#include "graphics/render-list.hpp"
+#include <glm/ext.hpp>
+#include <optional>
+
+namespace tec::graphics::pass {
+
+class RenderPass {
+protected:
+	explicit RenderPass(std::string _pass_name) : pass_name(std::move(_pass_name)) {}
+public:
+	RenderPass(const RenderPass& other) = default;
+
+	RenderPass(RenderPass&& other) noexcept : inv_view_size(other.inv_view_size), projection(other.projection) {}
+
+	RenderPass& operator=(const RenderPass& other) {
+		if (this == &other)
+			return *this;
+		inv_view_size = other.inv_view_size;
+		projection = other.projection;
+		pass_name = other.pass_name;
+		return *this;
+	}
+
+	RenderPass& operator=(RenderPass&& other) noexcept {
+		if (this == &other)
+			return *this;
+		inv_view_size = other.inv_view_size;
+		projection = other.projection;
+		pass_name = other.pass_name;
+		return *this;
+	}
+
+	virtual ~RenderPass() = default;
+
+	virtual void Prepare(const GBuffer&) = 0;
+	virtual void Run(const gfx::ShaderSet&, const View&, const RenderItems&) = 0;
+	virtual void Complete(const GBuffer&) = 0;
+
+	void SetProjection(const glm::mat4 _projection) { this->projection = _projection; }
+	void SetInvViewSize(const glm::vec2 _inv_view_size) { this->inv_view_size = _inv_view_size; }
+
+	std::string_view GetPassName() { return this->pass_name; }
+
+protected:
+	glm::vec2 inv_view_size{};
+	glm::mat4 projection{0};
+	std::string pass_name{"BaseRenderBase"};
+};
+} // namespace tec::graphics::pass

--- a/client/graphics/passes/render-pass.hpp
+++ b/client/graphics/passes/render-pass.hpp
@@ -2,24 +2,22 @@
 
 #include "graphics/gbuffer.hpp"
 #include "graphics/render-list.hpp"
-#include <glm/ext.hpp>
-#include <optional>
+#include "graphics/viewport.hpp"
 
 namespace tec::graphics::pass {
 
 class RenderPass {
 protected:
-	explicit RenderPass(std::string _pass_name) : pass_name(std::move(_pass_name)) {}
+	explicit RenderPass(const std::string_view _pass_name) : pass_name(_pass_name) {}
+
 public:
 	RenderPass(const RenderPass& other) = default;
 
-	RenderPass(RenderPass&& other) noexcept : inv_view_size(other.inv_view_size), projection(other.projection) {}
+	RenderPass(RenderPass&& other) noexcept : pass_name(other.pass_name) {}
 
 	RenderPass& operator=(const RenderPass& other) {
 		if (this == &other)
 			return *this;
-		inv_view_size = other.inv_view_size;
-		projection = other.projection;
 		pass_name = other.pass_name;
 		return *this;
 	}
@@ -27,26 +25,19 @@ public:
 	RenderPass& operator=(RenderPass&& other) noexcept {
 		if (this == &other)
 			return *this;
-		inv_view_size = other.inv_view_size;
-		projection = other.projection;
 		pass_name = other.pass_name;
 		return *this;
 	}
 
 	virtual ~RenderPass() = default;
 
-	virtual void Prepare(const GBuffer&) = 0;
-	virtual void Run(const gfx::ShaderSet&, const View&, const RenderItems&) = 0;
-	virtual void Complete(const GBuffer&) = 0;
+	virtual void Prepare(GBuffer&) = 0;
+	virtual void Run(const gfx::ShaderSet&, const Viewport&, const View&, const RenderItems&) = 0;
+	virtual void Complete(GBuffer&) = 0;
 
-	void SetProjection(const glm::mat4 _projection) { this->projection = _projection; }
-	void SetInvViewSize(const glm::vec2 _inv_view_size) { this->inv_view_size = _inv_view_size; }
-
-	std::string_view GetPassName() { return this->pass_name; }
+	[[nodiscard]] std::string_view GetPassName() const { return this->pass_name; }
 
 protected:
-	glm::vec2 inv_view_size{};
-	glm::mat4 projection{0};
-	std::string pass_name{"BaseRenderBase"};
+	std::string_view pass_name{"BaseRenderBase"};
 };
 } // namespace tec::graphics::pass

--- a/client/graphics/render-item.hpp
+++ b/client/graphics/render-item.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "animation.hpp"
+#include "renderable.hpp"
+#include "resources/mesh.hpp"
+#include "vertex-buffer-object.hpp"
+
+namespace tec {
+
+struct RenderItem {
+	glm::vec3 model_position{};
+	glm::vec3 model_scale{};
+	glm::quat model_quat{};
+	std::vector<VertexGroup> vertex_groups;
+	std::shared_ptr<VertexBufferObject> vbo;
+	MeshFile* mesh_at_set{nullptr}; // used only for equality testing, does not own an object
+	bool animated{false};
+	Animation* animation{nullptr};
+};
+
+} // namespace tec

--- a/client/graphics/render-list.hpp
+++ b/client/graphics/render-list.hpp
@@ -1,0 +1,149 @@
+#pragma once
+
+#include <optional>
+#include <spdlog/spdlog.h>
+#include <utility>
+
+#include "animation.hpp"
+#include "entity.hpp"
+#include "render-item.hpp"
+#include "renderable.hpp"
+#include "shader.hpp"
+#include "view.hpp"
+
+namespace tec::graphics {
+using RenderableMap = Multiton<eid, Renderable*>;
+using RenderItems = std::map<std::shared_ptr<Shader>, std::set<RenderItem*>>;
+
+class RenderItemList {
+public:
+	void SetDefaultShader(std::shared_ptr<Shader> _default_shader) {
+		this->default_shader = std::move(_default_shader);
+	}
+	void UpdateRenderList(double delta) {
+		static auto _log = spdlog::get("console_log");
+		RenderItemList render_item_list;
+
+		if (auto& fallback_shader = this->default_shader; !fallback_shader) {
+			fallback_shader = ShaderMap::Get("debug");
+		}
+
+		// Loop through each renderable and update its model matrix.
+		for (auto itr = RenderableMap::Begin(); itr != RenderableMap::End(); ++itr) {
+			eid entity_id = itr->first;
+			Renderable* renderable = itr->second;
+			if (renderable->hidden) {
+				continue;
+			}
+			Entity entity(entity_id);
+			auto [_position, _orientation, _scale, _animation] =
+					entity.GetList<Position, Orientation, Scale, Animation>();
+			glm::vec3 position = renderable->local_translation;
+			if (_position) {
+				position += _position->value;
+			}
+			glm::quat orientation = renderable->local_orientation.value;
+			if (_orientation) {
+				orientation *= _orientation->value;
+			}
+			glm::vec3 scale(1.0);
+			if (_scale) {
+				scale = _scale->value;
+			}
+
+			auto& mesh = renderable->mesh;
+			auto& ri = renderable->render_item;
+			if (!mesh && ri) {
+				renderable->render_item.reset();
+				ri.reset();
+			}
+			if (mesh && (!ri || ri->mesh_at_set != mesh.get())) {
+				auto buffer_itr = mesh_buffers.find(mesh);
+				std::shared_ptr<VertexBufferObject> buffer;
+				if (buffer_itr == mesh_buffers.cend()) {
+					buffer = std::make_shared<VertexBufferObject>(vertex::VF_FULL);
+					buffer->Load(mesh);
+					mesh_buffers[mesh] = buffer;
+				}
+				else {
+					buffer = buffer_itr->second;
+				}
+				if (std::size_t group_count = buffer->GetVertexGroupCount(); group_count > 0) {
+					if (!ri) {
+						ri = std::make_shared<RenderItem>();
+					}
+					else {
+						ri->vertex_groups.clear();
+					}
+					ri->vbo = buffer;
+					ri->vertex_groups.reserve(group_count);
+					ri->mesh_at_set = mesh.get();
+					for (std::size_t i = 0; i < group_count; ++i) {
+						ri->vertex_groups.push_back(*buffer->GetVertexGroup(i));
+					}
+					renderable->render_item = ri;
+				}
+				else {
+					_log->warn("[RenderSystem] empty mesh on Renderable [{}]", entity_id);
+					renderable->render_item.reset();
+					ri.reset();
+				}
+			}
+
+			if (ri) {
+				if (ri->vbo->Update()) {
+					// the mesh updated it's contents
+					std::size_t group_count = ri->vbo->GetVertexGroupCount();
+					ri->vertex_groups.clear();
+					ri->vertex_groups.reserve(group_count);
+					for (std::size_t i = 0; i < group_count; ++i) {
+						ri->vertex_groups.push_back(*ri->vbo->GetVertexGroup(i));
+					}
+				}
+				ri->model_position = position;
+				ri->model_scale = scale;
+				ri->model_quat = orientation;
+
+				if (_animation) {
+					const_cast<Animation*>(_animation)->UpdateAnimation(delta);
+					if (_animation->HasBoneTransforms()) {
+						ri->animated = true;
+						ri->animation = const_cast<Animation*>(_animation);
+					}
+				}
+				this->render_items[renderable->shader].insert(ri.get());
+			}
+		}
+
+		for (auto itr = Multiton<eid, View*>::Begin(); itr != Multiton<eid, View*>::End(); ++itr) {
+			auto& [entity_id, view] = *itr;
+
+			Entity entity(entity_id);
+			auto [_position, _orientation] = entity.GetList<Position, Orientation>();
+			glm::vec3 position;
+			if (_position) {
+				position = _position->value;
+			}
+			glm::quat orientation;
+			if (_orientation) {
+				orientation = _orientation->value;
+			}
+
+			view->view_pos = -position;
+			view->view_quat = glm::inverse(orientation);
+			if (view->active) {
+				this->current_view = *view;
+			}
+		}
+	}
+
+	RenderItems& GetRenderItems() { return this->render_items; }
+	std::optional<View> GetCurrentView() const { return this->current_view; }
+
+private:
+	std::map<std::shared_ptr<MeshFile>, std::shared_ptr<VertexBufferObject>> mesh_buffers;
+	RenderItems render_items;
+	std::shared_ptr<Shader> default_shader;
+	std::optional<View> current_view;
+};
+} // namespace tec::graphics

--- a/client/graphics/shader.cpp
+++ b/client/graphics/shader.cpp
@@ -7,6 +7,7 @@
 #include <spdlog/spdlog.h>
 
 #include "gbuffer.hpp"
+#include "gl-symbol.hpp"
 #include "proto-load.hpp"
 #include "render-system.hpp"
 
@@ -201,7 +202,7 @@ bool Shader::Build(const std::string& name) {
 		GLenum sym_type;
 		glGetActiveUniform(this->program, index, max_read_size, &written, &uniform_size, &sym_type, max_read.data());
 		std::string uniform_name = max_read.substr(0, max_read.find_first_of('\0'));
-		std::string s_type{GLSymbol::Get(sym_type).name};
+		std::string s_type{graphics::GLSymbol::Get(sym_type).name};
 		GLint uniform_loc = this->GetUniformLocation(uniform_name);
 		_log->trace("[Shader] {}/uniform: {}: {} {}: {}", name, uniform_loc, uniform_size, s_type, uniform_name);
 		if (sym_type == GL_SAMPLER_2D) {
@@ -218,7 +219,7 @@ bool Shader::Build(const std::string& name) {
 		GLenum sym_type;
 		glGetActiveAttrib(this->program, index, max_read_size, &written, &attrib_size, &sym_type, max_read.data());
 		std::string attrib_name = max_read.substr(0, max_read.find_first_of('\0'));
-		std::string s_type{GLSymbol::Get(sym_type).name};
+		std::string s_type{graphics::GLSymbol::Get(sym_type).name};
 		GLint attrib_loc = this->GetAttributeLocation(attrib_name);
 		_log->trace("[Shader] {}/attrib: {}: {} {}: {}", name, attrib_loc, attrib_size, s_type, attrib_name);
 	}

--- a/client/graphics/texture-object.cpp
+++ b/client/graphics/texture-object.cpp
@@ -1,4 +1,6 @@
 #include "texture-object.hpp"
+
+#include "gl-symbol.hpp"
 #include "render-system.hpp"
 
 #include <spdlog/spdlog.h>
@@ -88,8 +90,8 @@ void TextureObject::Load(const PixelBuffer& image) {
 				"[TextureObject] Allocate {}x{} in {} from {}",
 				image.Width(),
 				image.Height(),
-				GLSymbol::Get(format.to),
-				GLSymbol::Get(format.from));
+				graphics::GLSymbol::Get(format.to),
+				graphics::GLSymbol::Get(format.from));
 	}
 	else {
 		glBindTexture(GL_TEXTURE_2D, this->texture_id);

--- a/client/graphics/vertex-buffer-object.hpp
+++ b/client/graphics/vertex-buffer-object.hpp
@@ -35,7 +35,7 @@ public:
 	* note: this method is not const, since GL can modify the ID
 	* \return GLuint the GL texture ID.
 	*/
-	GLuint GetVAO() { return this->vao; }
+	GLuint GetVAO() const { return this->vao; }
 
 	/**
 	* \brief Gets the specified VertexGroup.
@@ -43,6 +43,8 @@ public:
 	* \return VertexGroup& The specified VertexGroup.
 	*/
 	VertexGroup* GetVertexGroup(const std::size_t vertex_group_number);
+
+	GLuint GetVertexGroupIndexCount(const std::size_t index) const { return this->vertex_groups.at(index).index_count; }
 
 	/**
 	* \brief Gets the number of vertex groups store in the buffer.

--- a/client/graphics/view.hpp
+++ b/client/graphics/view.hpp
@@ -6,9 +6,9 @@
 
 namespace tec {
 struct View {
-	View(bool active = false) : active(active) {}
+	explicit View(const bool active = false) : active(active) {}
 	glm::vec3 view_pos{0};
-	glm::quat view_quat;
+	glm::quat view_quat{};
 	bool active = false;
 
 	void Out(proto::Component* target) {

--- a/client/graphics/view.hpp
+++ b/client/graphics/view.hpp
@@ -6,7 +6,7 @@
 
 namespace tec {
 struct View {
-	explicit View(const bool active = false) : active(active) {}
+	View(bool active = false) : active(active) {}
 	glm::vec3 view_pos{0};
 	glm::quat view_quat{};
 	bool active = false;

--- a/client/graphics/viewport.hpp
+++ b/client/graphics/viewport.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace tec::graphics {
+
+struct Viewport {
+	glm::uvec2 view_size;
+	glm::vec2 inv_view_size;
+	glm::mat4 projection;
+};
+
+} // namespace tec::graphics

--- a/client/render-system.cpp
+++ b/client/render-system.cpp
@@ -107,7 +107,8 @@ void RenderSystem::Startup() {
 		_log->debug("[RenderSystem] Error loading quad.obj.");
 	}
 	else {
-		quad_vbo.Load(quad);
+		quad_vbo = std::make_unique<VertexBufferObject>(vertex::VF_BASE);
+		quad_vbo->Load(quad);
 	}
 
 	this->render_passes.push_back(std::make_shared<graphics::pass::GeometryPass>());

--- a/client/render-system.hpp
+++ b/client/render-system.hpp
@@ -1,19 +1,15 @@
 #pragma once
 
-#include <map>
-#include <memory>
-#include <set>
-#include <unordered_set>
-
 #include <glad/glad.h>
-#include <fmt/core.h>
-#include <glm/gtc/quaternion.hpp>
-#include <glm/vec3.hpp>
 #include <graphics.pb.h>
+#include <memory>
+#include <unordered_set>
 
 #include "command-queue.hpp"
 #include "event-system.hpp"
 #include "graphics/gbuffer.hpp"
+#include "graphics/passes/render-pass.hpp"
+#include "graphics/render-list.hpp"
 #include "graphics/vertex-buffer-object.hpp"
 #include "tec-types.hpp"
 
@@ -22,10 +18,6 @@ class logger;
 }
 
 namespace tec {
-struct VertexGroup;
-struct View;
-class Shader;
-class Animation;
 class Console;
 
 class RenderSystem;
@@ -34,23 +26,6 @@ typedef Command<RenderSystem> RenderCommand;
 struct WindowResizedEvent;
 struct EntityDestroyed;
 struct EntityCreated;
-
-struct RenderItem {
-	glm::vec3 model_position{};
-	glm::vec3 model_scale{};
-	glm::quat model_quat{};
-	std::vector<VertexGroup> vertex_groups;
-	std::shared_ptr<VertexBufferObject> vbo;
-	MeshFile* mesh_at_set{nullptr}; // used only for equality testing, does not own an object
-	bool animated{false};
-	Animation* animation{nullptr};
-};
-
-class GLSymbol {
-public:
-	static const GLSymbol& Get(GLenum which);
-	std::string name;
-};
 
 class RenderSystem final :
 		public CommandQueue<RenderSystem>,
@@ -62,7 +37,7 @@ public:
 
 	void RegisterConsole(Console& console);
 
-	void SetViewportSize(const glm::uvec2& _view_size);
+	void SetViewportSize(const glm::uvec2& view_size);
 
 	void Update(double delta);
 
@@ -70,52 +45,29 @@ public:
 
 	static void ErrorCheck(std::string_view what, size_t line, std::string_view where = "RenderSystem");
 
+	static void ActivateMaterial(const Material&);
+
+	static void DeactivateMaterial(const Material&, const GLuint*);
+
+	inline static VertexBufferObject quad_vbo{vertex::VF_BASE};
+
 private:
 	static std::shared_ptr<spdlog::logger> _log;
-
-	void GeometryPass();
-	void BeginPointLightPass();
-	void DirectionalLightPass();
-	void FinalPass();
-	void RenderGbuffer();
-
-	static void ActivateMaterial(const Material&);
-	static void DeactivateMaterial(const Material&, const GLuint*);
+	
 	static void SetupDefaultShaders(const gfx::RenderConfig&);
 
 	void On(eid, std::shared_ptr<WindowResizedEvent> data) override;
 	void On(eid, std::shared_ptr<EntityDestroyed> data) override;
 	void On(eid, std::shared_ptr<EntityCreated> data) override;
-	void UpdateRenderList(double delta);
 
-	glm::mat4 projection{0};
-	View* current_view{nullptr};
-	glm::uvec2 view_size{1024, 768};
-	glm::vec2 inv_view_size{};
-	std::shared_ptr<Shader> default_shader;
 	gfx::RenderOptions options;
 	gfx::ShaderSet active_shaders;
 
 	GBuffer light_gbuffer;
-	VertexBufferObject sphere_vbo{vertex::VF_BASE}; // Used for rendering point lights.
-	VertexBufferObject quad_vbo{vertex::VF_BASE}; // Used for rendering directional lights.
 
 	// all the functional extensions this GL supports
 	std::unordered_set<std::string> extensions;
-	std::map<std::shared_ptr<MeshFile>, std::shared_ptr<VertexBufferObject>> mesh_buffers;
-	std::map<std::shared_ptr<Shader>, std::set<RenderItem*>> render_item_list;
+	graphics::RenderItemList render_item_list;
+	std::vector<std::shared_ptr<graphics::pass::RenderPass>> render_passes;
 };
 } // namespace tec
-
-template <> struct fmt::formatter<tec::GLSymbol> {
-	static constexpr auto parse(const format_parse_context& ctx) -> decltype(ctx.begin()) {
-		const auto it = ctx.begin();
-		if (const auto end = ctx.end(); it != end && *it != '}')
-			static_assert(R"(invalid format)");
-		return it;
-	}
-	template <typename FormatContext>
-	static auto format(const tec::GLSymbol& p, FormatContext& ctx) -> decltype(ctx.out()) {
-		return fmt::format_to(ctx.out(), "{}", p.name);
-	}
-};

--- a/client/render-system.hpp
+++ b/client/render-system.hpp
@@ -11,6 +11,7 @@
 #include "graphics/passes/render-pass.hpp"
 #include "graphics/render-list.hpp"
 #include "graphics/vertex-buffer-object.hpp"
+#include "graphics/viewport.hpp"
 #include "tec-types.hpp"
 
 namespace spdlog {
@@ -53,8 +54,9 @@ public:
 
 private:
 	static std::shared_ptr<spdlog::logger> _log;
-	
+
 	static void SetupDefaultShaders(const gfx::RenderConfig&);
+	void UpdateViewport(const glm::uvec2& view_size);
 
 	void On(eid, std::shared_ptr<WindowResizedEvent> data) override;
 	void On(eid, std::shared_ptr<EntityDestroyed> data) override;
@@ -69,5 +71,6 @@ private:
 	std::unordered_set<std::string> extensions;
 	graphics::RenderItemList render_item_list;
 	std::vector<std::shared_ptr<graphics::pass::RenderPass>> render_passes;
+	graphics::Viewport viewport{};
 };
 } // namespace tec

--- a/client/render-system.hpp
+++ b/client/render-system.hpp
@@ -49,7 +49,7 @@ public:
 
 	static void DeactivateMaterial(const Material&, const GLuint*);
 
-	inline static VertexBufferObject quad_vbo{vertex::VF_BASE};
+	inline static std::unique_ptr<VertexBufferObject> quad_vbo;
 
 private:
 	static std::shared_ptr<spdlog::logger> _log;


### PR DESCRIPTION
Rework render system to have passes

## Description
Removed all "pass" related code from render system. Added base RenderPass class interface. DRY'd up RenderSystem::Update by storing all passes in a vector and iterating them rather than explicitly laying out the render loop.

Extracted render item list into its own class, moves in the direction of a scene graph.

Made several GBuffer methods const as they were const.

Removed some class state that didn't need to be stored as it was computed from an event, or it was being created every frame regardless.

Extract GLSymbol into it's own file to reduce the size of the RenderSystem files.

## Motivation and Context
This makes the render system a bit more configurable and declarative. This was also an opportunity for me to practice some more modern c++ libraries and features.

I tried to keep the existing loop in tact as much as possible, the goal was to refactor into smaller chunks, not improve/enhance the existing code.

## How Has This Been Tested?
All current tests pass. Running the application appears to yield the same visual result as before

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/3011917/200496907-66da1ee0-2af8-41b5-9268-8df49bbf58bf.png)
![image](https://user-images.githubusercontent.com/3011917/200496956-89d2a3eb-e132-4c50-a32c-3b258cf2a022.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
